### PR TITLE
Add metal3ci user to image userdata

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -6,6 +6,12 @@ users:
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     groups: ${DEFAULT_SSH_USER_GROUP}
     shell: /bin/bash
+  - name: metal3ci
+    ssh-authorized-keys:
+      - ${SSH_AUTHORIZED_KEY}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: wheel
+    shell: /bin/bash
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts

--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -6,6 +6,12 @@ users:
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     groups: ${DEFAULT_SSH_USER_GROUP}
     shell: /bin/bash
+  - name: metal3ci
+    ssh-authorized-keys:
+      - ${SSH_AUTHORIZED_KEY}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts


### PR DESCRIPTION
This adds a metal3ci user to image userdata. The airshipci user will still be created and used by the scripts. This additional user will let us swap over to using the metal3ci user once images have been built with both users.