### PR TITLE
Rename prefix of OpenStack networks from airship to metal3

### DIFF
--- a/ci/scripts/image_scripts/start_centos_ipa_ironic_build.sh
+++ b/ci/scripts/image_scripts/start_centos_ipa_ironic_build.sh
@@ -8,7 +8,7 @@ BUILDER_PORT_NAME="${BUILDER_PORT_NAME:-${BUILDER_VM_NAME}-int-port}"
 BUILDER_FLAVOR="${BUILDER_FLAVOR:-8C-16GB-200GB}"
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 IPA_BUILDER_SCRIPT_NAME="${IPA_BUILDER_SCRIPT_NAME:-build_ipa.sh}"
-CI_EXT_NET="airship-ci-ext-net"
+CI_EXT_NET="metal3-ci-ext-net"
 IMAGE_NAME="airship-ci-ubuntu-metal3-img"
 
 # shellcheck disable=SC1090

--- a/ci/scripts/openstack/README.md
+++ b/ci/scripts/openstack/README.md
@@ -30,8 +30,8 @@ DEV Infrastructure like CI infra contains basic components like routers, externa
 
 Resources which developers can use directly are
 
-- ***External Network***: airship-dev-ext-net
-- ***External Network Subnet***: airship-dev-ext-net-subnet
+- ***External Network***: metal3-dev-ext-net
+- ***External Network Subnet***: metal3-dev-ext-net-subnet
 
 #### Create Dev Infrastructure
 

--- a/ci/scripts/openstack/infra_defines.sh
+++ b/ci/scripts/openstack/infra_defines.sh
@@ -9,10 +9,9 @@ EXT_NET="ext-net"
 # Global defines for Airship CI infrastructure
 # ============================================
 
-CI_ROUTER_NAME="airship-ci-ext-router"
-CI_EXT_NET="airship-ci-ext-net"
+CI_ROUTER_NAME="metal3-ci-ext-router"
+CI_EXT_NET="metal3-ci-ext-net"
 CI_EXT_SUBNET_CIDR="10.100.10.0/24"
-CI_INT_NET="airship-ci-int-net"
 CI_INT_SUBNET_CIDR="10.0.10.0/24"
 CI_KEYPAIR_NAME="airshipci-key"
 CI_BASE_IMAGE="airship-ci-ubuntu-base-img"
@@ -28,10 +27,9 @@ VM_PREFIX_CENTOS="centos"
 # Global defines for Airship DEV infrastructure
 # =============================================
 
-DEV_ROUTER_NAME="airship-dev-ext-router"
-DEV_EXT_NET="airship-dev-ext-net"
+DEV_ROUTER_NAME="metal3-dev-ext-router"
+DEV_EXT_NET="metal3-dev-ext-net"
 DEV_EXT_SUBNET_CIDR="10.101.10.0/24"
-DEV_INT_NET="airship-dev-int-net"
 DEV_INT_SUBNET_CIDR="10.1.10.0/24"
 DEV_JUMPHOST_NAME="airship-dev-jumphost"
 DEV_JUMPHOST_FLOATING_IP_TAG="airship_dev_jumphost_fip"


### PR DESCRIPTION
Also remove unused `CI_INT_NET` and `DEV_INT_NET`.
