### PR TITLE
Trigger image building job after node image building job

### DIFF
--- a/ci/jobs/openstack_node_image_building.pipeline
+++ b/ci/jobs/openstack_node_image_building.pipeline
@@ -98,5 +98,11 @@ pipeline {
         }
       }
     }
+  }
+  post{
+    success {
+            echo 'Run metal3_openstack_image_building job'
+            build job: 'metal3_openstack_image_building'
+        }
   }      
 }


### PR DESCRIPTION
This PR adds post section in node_image_building pipeline, which triggers image_building job after its successful run
