### PR TITLE
Pass KUBERNETES_VERSION value to image building stage of metal3 dev tools integration tests

### DIFF
--- a/ci/jobs/metal3_dev_tools_integration_tests.pipeline
+++ b/ci/jobs/metal3_dev_tools_integration_tests.pipeline
@@ -70,6 +70,7 @@ pipeline {
       --env OS_USERNAME \
       --env OS_PASSWORD \
       --env DST_FOLDER \
+      --env KUBERNETES_VERSION \
       --env FINAL_IMAGE_NAME"
     CURRENT_DIR = sh (
                       script: 'readlink -f "."',


### PR DESCRIPTION
This PR adds passing KUBERNETES_VERSION to node image building stage of airship dev tools integration tests, so temporary images are being built with correct k8s version. 