### PR TITLE
Fix passing k8s version to metal3 dev tools integration test pipeline

### DIFF
--- a/ci/jobs/metal3_dev_tools_integration_tests.pipeline
+++ b/ci/jobs/metal3_dev_tools_integration_tests.pipeline
@@ -51,7 +51,7 @@ pipeline {
     IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/metal3/images/temp/"
     DST_FOLDER="metal3/images/temp"
     FINAL_IMAGE_NAME="${DISTRIBUTION}_TEMP_IMG_${RAND_NAME}"
-    KUBERNETES_VERSION="${KUBERNETES_VERSION}"
+    KUBERNETES_VERSION="${KUBERNETES_VERSION ?: 'v1.23.3' }"
     
     DOCKER_CMD_ENV="--env METAL3_CI_USER \
       --env METAL3_CI_USER_KEY=/data/id_rsa_metal3ci \


### PR DESCRIPTION
This PR we are setting default KUBERNETES_VERSION value  in metal dev tools interation tests pipeline