### PR TITLE
Update script for building metal3 images locally

### DIFF
--- a/ci/images/README.md
+++ b/ci/images/README.md
@@ -84,3 +84,40 @@ The centos building scripts take three arguments :
    ./gen_<xxx>_<centos>_image.sh /data/keys/id_rsa_metal3ci 1 <provisioner script>
    ```
 
+### Building and testing locally
+
+The scripts mentioned above (gen_*_image.sh) are made for use in our CI pipelines.
+As such, they make certain assumptions that may not be ideal when developing and testing things locally (e.g. keypair name and ssh-key path).
+
+For these situations there is another script: `run_local.sh`.
+It allows overriding many variables and skips things like uploading the images to Artifactory.
+
+This is how you use it:
+
+1. Check the comments and variables at the top of `run_local.sh` and determine what you want/need to override.
+2. Create a file with your custom variables.
+3. Get an openstack.rc file with credentials to the cloud you want to build in.
+4. Source your variables, source the openstack.rc.
+5. Run the script: `./run_local.sh <provisioning-script>`
+
+Here is an example of custom variables:
+
+```shell
+# My custom variables
+export SSH_USER_NAME="foo"
+export SSH_USER_GROUP="wheel"
+export SSH_KEYPAIR_NAME="foo-key"
+export SSH_PUBLIC_KEY_FILE="/home/foo/.ssh/id_rsa.pub"
+export SSH_PRIVATE_KEY_FILE="/home/foo/.ssh/id_rsa"
+export IMAGE_NAME="foo-test-image"
+export SOURCE_IMAGE_NAME="Upstream-centos-or-ubuntu"
+export NETWORK="abcdefg"
+```
+
+And here is how to use it:
+
+```console
+$ source vars.sh
+$ source openstack.rc
+$ ./run_local.sh provision_metal3_image.sh
+```

--- a/ci/images/gen_base_ubuntu_image.sh
+++ b/ci/images/gen_base_ubuntu_image.sh
@@ -28,7 +28,6 @@ FLOATING_IP_NETWORK="$( [ "${USE_FLOATING_IP}" = 1 ] && echo "${EXT_NET}")"
 REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/provision_base_image.sh"
 SSH_USER_GROUP="sudo"
 
-SOURCE_IMAGE="$(get_resource_id_from_name image "${SOURCE_IMAGE_NAME}")"
 SSH_AUTHORIZED_KEY="$(cat "${OS_SCRIPTS_DIR}/id_rsa_metal3ci.pub")"
 render_user_data \
   "${SSH_AUTHORIZED_KEY}" \
@@ -50,7 +49,7 @@ create_keypair "${CI_PUBLIC_KEY_FILE}" "${SSH_KEYPAIR_NAME}"
 # Build Image
 packer build \
   -var "image_name=${IMAGE_NAME}" \
-  -var "source_image=${SOURCE_IMAGE}" \
+  -var "source_image_name=${SOURCE_IMAGE_NAME}" \
   -var "user_data_file=${USER_DATA_FILE}" \
   -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
   -var "ssh_username=${SSH_USER_NAME}" \

--- a/ci/images/gen_jumphost_jenkins_ubuntu_image.sh
+++ b/ci/images/gen_jumphost_jenkins_ubuntu_image.sh
@@ -27,7 +27,6 @@ FLOATING_IP_NETWORK="$( ([ "${USE_FLOATING_IP}" = 1 ] && echo "${EXT_NET}"))" ||
 REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/provision_jumphost_jenkins_base_img.sh"
 SSH_USER_GROUP="sudo"
 
-SOURCE_IMAGE="$(get_resource_id_from_name image "${SOURCE_IMAGE_NAME}")"
 SSH_AUTHORIZED_KEY="$(cat "${OS_SCRIPTS_DIR}/id_rsa_metal3ci.pub")"
 render_user_data \
   "${SSH_AUTHORIZED_KEY}" \
@@ -48,7 +47,7 @@ create_keypair "${CI_PUBLIC_KEY_FILE}" "${SSH_KEYPAIR_NAME}"
 # Build Image
 packer build \
   -var "image_name=${IMAGE_NAME}" \
-  -var "source_image=${SOURCE_IMAGE}" \
+  -var "source_image_name=${SOURCE_IMAGE_NAME}" \
   -var "user_data_file=${USER_DATA_FILE}" \
   -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
   -var "ssh_username=${SSH_USER_NAME}" \

--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -46,7 +46,7 @@ NETWORK="$(get_resource_id_from_name network "${CI_EXT_NET}")"
 FLOATING_IP_NETWORK="$( [ "${USE_FLOATING_IP}" = 1 ] && echo "${EXT_NET}")"
 REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/${PROVISIONING_SCRIPT}"
 SSH_USER_GROUP="wheel"
-SOURCE_IMAGE="$(get_resource_id_from_name image "${SOURCE_IMAGE_NAME}")"
+
 SSH_AUTHORIZED_KEY="$(cat "${OS_SCRIPTS_DIR}/id_rsa_metal3ci.pub")"
 render_user_data \
   "${SSH_AUTHORIZED_KEY}" \
@@ -67,7 +67,7 @@ create_keypair "${CI_PUBLIC_KEY_FILE}" "${SSH_KEYPAIR_NAME}"
 # Build Image
 packer build \
   -var "image_name=${IMAGE_NAME}" \
-  -var "source_image=${SOURCE_IMAGE}" \
+  -var "source_image_name=${SOURCE_IMAGE_NAME}" \
   -var "user_data_file=${USER_DATA_FILE}" \
   -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
   -var "ssh_username=${SSH_USER_NAME}" \

--- a/ci/images/gen_metal3_ubuntu_image.sh
+++ b/ci/images/gen_metal3_ubuntu_image.sh
@@ -27,7 +27,6 @@ FLOATING_IP_NETWORK="$( [ "${USE_FLOATING_IP}" = 1 ] && echo "${EXT_NET}")"
 REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/provision_metal3_image.sh"
 SSH_USER_GROUP="sudo"
 
-SOURCE_IMAGE="$(get_resource_id_from_name image "${SOURCE_IMAGE_NAME}")"
 SSH_AUTHORIZED_KEY="$(cat "${OS_SCRIPTS_DIR}/id_rsa_metal3ci.pub")"
 render_user_data \
   "${SSH_AUTHORIZED_KEY}" \
@@ -48,7 +47,7 @@ create_keypair "${CI_PUBLIC_KEY_FILE}" "${SSH_KEYPAIR_NAME}"
 # Build Image
 packer build \
   -var "image_name=${IMAGE_NAME}" \
-  -var "source_image=${SOURCE_IMAGE}" \
+  -var "source_image_name=${SOURCE_IMAGE_NAME}" \
   -var "user_data_file=${USER_DATA_FILE}" \
   -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
   -var "ssh_username=${SSH_USER_NAME}" \

--- a/ci/images/image_builder_template.json
+++ b/ci/images/image_builder_template.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "image_name": "",
-    "source_image": "4654e14c-f667-4e24-a538-c792b57c5bc8",
+    "source_image_name": "",
     "user_data_file": "userdata",
     "exec_script_path": "",
     "ssh_username": "metal3ci",
@@ -9,6 +9,7 @@
     "ssh_private_key_file": "",
     "network": "282a8c18-614c-4fbc-9928-b66d56ae3cbe",
     "floating_ip_net": "",
+    "reuse_ips": "false",
     "local_scripts_dir": "../scripts",
     "ssh_pty": "false",
     "flavor":"2C-16GB-20GB"
@@ -16,11 +17,11 @@
   "builders": [{
     "type": "openstack",
     "image_name": "{{user `image_name`}}",
-    "source_image": "{{user `source_image`}}",
+    "source_image_name": "{{user `source_image_name`}}",
     "user_data_file": "{{user `user_data_file`}}",
     "flavor":  "{{user `flavor`}}",
-    "reuse_ips": false,
-    "ssh_keypair_name": "metal3ci-key",
+    "reuse_ips": "{{user `reuse_ips`}}",
+    "ssh_keypair_name": "{{user `ssh_keypair_name`}}",
     "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
     "networks": "{{user `network`}}",
     "floating_ip_network": "{{user `floating_ip_net`}}",

--- a/ci/images/run_local.sh
+++ b/ci/images/run_local.sh
@@ -4,33 +4,89 @@
 # scripts. It reproduces the CI environment.
 #
 # This requires the openstack.rc file to have been sourced and
-# takes two parameters:
+# takes one parameters:
 # - the file name of the script to run
-# - the absolute path to the metal3ci user ssh private key
+#
+# There are some variables in this script that can be overridden and some are
+# required. See comments below.
 
 # For example:
+# $ source my-custom-vars.sh
 # $ source openstack.rc
-# $ ./run_local.sh gen_metal3_centos_volume.sh ~/keys/metal3ci_id_rsa
+# $ ./run_local.sh provision_metal3_image_centos.sh
 
 set -eux
 
-SCRIPT="${1}"
-KEY_PATH="${2}"
+PROVISIONING_SCRIPT="${1:?}"
 
+#
+# Required variables:
+#
+# - SSH_KEYPAIR_NAME: Name of the keypair in openstack
+
+#
+# Overridable variables
+#
+# These variables can be overridden by the user, but have defaults that may or
+# may not be useful.
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
-METAL3_CI_USER="metal3ci"
-RT_URL="https://artifactory.nordix.org/artifactory"
-OS_AUTH_URL="https://kna1.citycloud.com:5000"
-OS_USER_DOMAIN_NAME="CCP_Domain_37137"
-OS_PROJECT_DOMAIN_NAME="CCP_Domain_37137"
-OS_REGION_NAME="Kna1"
-OS_PROJECT_NAME="Default Project 37137"
-OS_TENANT_NAME="Default Project 37137"
-OS_AUTH_VERSION=3
-OS_IDENTITY_API_VERSION=3
+SSH_USER_NAME="${SSH_USER_NAME:-${USER}}"
+SSH_PUBLIC_KEY_FILE="${SSH_PUBLIC_KEY_FILE:-/home/${USER}/.ssh/id_rsa.pub}"
+SSH_PRIVATE_KEY_FILE="${SSH_PRIVATE_KEY_FILE:-/home/${USER}/.ssh/id_rsa}"
+IMAGE_NAME="${IMAGE_NAME:-${USER}-test}"
+# Image to start build from. For example Ubuntu-20.04 or CentOS-Stream-GenericCloud-8
+SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-CentOS-Stream-GenericCloud-8}"
+# Group to add user to. To get sudo access on CentOS: wheel, on Ubuntu: sudo
+SSH_USER_GROUP="${SSH_USER_GROUP:-wheel}"
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.23.5"}
+
+# The variables below should not need to be touched by the user
+if [[ "$PROVISIONING_SCRIPT" == *"node"* ]]; then
+  BUILDER_CONFIG_FILE="image_builder_template_node.json"
+  IMAGE_FLAVOR="1C-4GB-20GB"
+elif [[ "$PROVISIONING_SCRIPT" == *"metal3"* ]]; then
+  BUILDER_CONFIG_FILE="image_builder_template.json"
+  IMAGE_FLAVOR="4C-16GB-50GB"
+else
+  echo "Available provisioning scripts are:"
+  echo "$(ls -l ../scripts/image_scripts/provision_* | cut -f4 -d'/')"
+  exit 1
+fi
+
+DEV_TOOLS="$(dirname "$(readlink -f "${0}")")/../../"
+OS_SCRIPTS_DIR="${DEV_TOOLS}/ci/scripts/openstack"
+IMAGES_DIR="${DEV_TOOLS}/ci/images"
+
+# shellcheck disable=SC1090
+source "${OS_SCRIPTS_DIR}/infra_defines.sh"
+# shellcheck disable=SC1090
+source "${OS_SCRIPTS_DIR}/utils.sh"
+
+NETWORK_NAME="${DEV_EXT_NET}"
+FLOATING_IP_NETWORK="${EXT_NET}"
+REUSE_IPS="true"
+# get_resource_id_from_name assumes that the openstack CLI is installed locally.
+# If this is not the case, set the NETWORK directly instead.
+NETWORK="${NETWORK:-$(get_resource_id_from_name network "${NETWORK_NAME}")}"
+
+TMP="$(mktemp -d)"
+USER_DATA_FILE="${TMP}/userdata"
+STARTER_SCRIPT_PATH="${TMP}/build_starter.sh"
+
+REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/${PROVISIONING_SCRIPT}"
+echo "${REMOTE_EXEC_CMD}" > "${STARTER_SCRIPT_PATH}"
+
+SSH_AUTHORIZED_KEY="$(cat "${SSH_PUBLIC_KEY_FILE}")"
+render_user_data \
+  "${SSH_AUTHORIZED_KEY}" \
+  "${SSH_USER_NAME}" \
+  "${SSH_USER_GROUP}" \
+  "${IMAGE_NAME}" \
+  "${IMAGES_DIR}/centos_userdata.tpl" \
+  "${USER_DATA_FILE}"
+
 CR_CMD_ENV="--env METAL3_CI_USER \
   --env METAL3_CI_USER_KEY=/data/id_rsa_metal3ci \
-  --env RT_URL \
   --env OS_AUTH_URL \
   --env OS_USER_DOMAIN_NAME \
   --env OS_PROJECT_DOMAIN_NAME \
@@ -41,13 +97,30 @@ CR_CMD_ENV="--env METAL3_CI_USER \
   --env OS_IDENTITY_API_VERSION \
   --env OS_USERNAME \
   --env OS_PASSWORD "
-CURRENT_DIR="$(dirname "$(readlink -f "${0}")")/../../"
+
+# Paths inside the container
+CONTAINER_SCRIPTS_DIR="/data/metal3-dev-tools/ci/scripts/image_scripts"
+CONTAINER_IMAGES_DIR="/data/metal3-dev-tools/ci/images"
 
 # Run the script in a docker container
 "${CONTAINER_RUNTIME}" run --rm \
   ${CR_CMD_ENV}\
-  -v ${CURRENT_DIR}:/data \
-  -v ${KEY_PATH}:/data/id_rsa_metal3ci \
+  -v ${DEV_TOOLS}:/data/metal3-dev-tools \
+  -v ${SSH_PRIVATE_KEY_FILE}:/data/private_key \
+  -v ${TMP}:${TMP} \
   registry.nordix.org/metal3/image-builder \
-  /data/ci/images/${SCRIPT} \
-  /data/id_rsa_metal3ci 1
+  packer build \
+    -var "image_name=${IMAGE_NAME}" \
+    -var "source_image_name=${SOURCE_IMAGE_NAME}" \
+    -var "user_data_file=${USER_DATA_FILE}" \
+    -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
+    -var "ssh_username=${SSH_USER_NAME}" \
+    -var "ssh_keypair_name=${SSH_KEYPAIR_NAME}" \
+    -var "ssh_private_key_file=/data/private_key" \
+    -var "network=${NETWORK}" \
+    -var "floating_ip_net=${FLOATING_IP_NETWORK}" \
+    -var "reuse_ips=${REUSE_IPS}" \
+    -var "local_scripts_dir=${CONTAINER_SCRIPTS_DIR}" \
+    -var "ssh_pty=true" \
+    -var "flavor=${IMAGE_FLAVOR}" \
+    "${CONTAINER_IMAGES_DIR}/${BUILDER_CONFIG_FILE}"


### PR DESCRIPTION
- Use source image name directly instead of searching for the ID based on the name.
- Remove hard coded source image
- Parameterize ssh_keypair_name and reuse_ips
- Provide overridable defaults for local script
- Don't upload locally built images to artifactory