### PR TITLE
Fix cloud-init error on centos

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -15,8 +15,3 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
-  # Make /etcd/resolv.conf immutable in order to prevent NetworkManager
-  # from overriding DNS entries with values from DHCP servers
-  # This removes network settings of the image building environment from the image.
-  - echo $'nameserver 8.8.8.8\nnameserver 8.8.4.4' > /etc/resolv.conf
-  - chattr +i /etc/resolv.conf

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -17,6 +17,37 @@ export IMAGE_OS="${IMAGE_OS:-Centos}"
 export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-minikube}"
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+# Disable cloud-init network configuration that would overwrite the network config.
+cat <<EOF | sudo tee /etc/cloud/cloud.cfg.d/01-network.cfg
+network:
+  config: disabled
+# resolv.conf is managed by NetworkManager, cloud-init should not touch it
+manage_resolv_conf: false
+EOF
+# Even with the above, cloud-init will configure NetworkManager to not touch
+# resolv.conf *if* there is a nameserver configured for the subnet in openstack.
+# This is done in the following file, that we remove to let NM handle resolv.conf
+# Ref https://bugs.launchpad.net/cloud-init/+bug/1693251
+sudo rm /etc/NetworkManager/conf.d/99-cloud-init.conf || true
+sudo systemctl restart NetworkManager
+# Configure network (set nameservers, disable peer DNS and remove mac address
+# that was automatically added). The rest of the fields are kept as is.
+cat <<EOF | sudo tee /etc/sysconfig/network-scripts/ifcfg-eth0
+NAME="System eth0"
+BOOTPROTO=dhcp
+DEVICE=eth0
+MTU=1500
+ONBOOT=yes
+TYPE=Ethernet
+USERCTL=no
+PEERDNS=no
+DNS1=8.8.8.8
+DNS2=8.8.4.4
+EOF
+# Apply the changes
+sudo nmcli connection reload
+sudo nmcli connection up "System eth0"
+
 sudo dnf distro-sync -y
 sudo dnf update -y curl nss
 sudo dnf install -y git make


### PR DESCRIPTION
resolv.conf was previously made immutable to prevent NetworkManager
and/or cloud-init from modifying it. This was causing issues with
cloud-init, since it still tried to modify it.

Most of the time things worked ok (except that cloud-init had error
status). But every now and then this error seemed to cause other issues.
E.g. the resizing of the filesystem or injection of authorized
ssh keys failed.

This commit properly configures NetworkManager to set the nameservers
and cloud-init to avoid touching resolv.conf.