### PR TITLE
Fix nameservers on centos node images

### DIFF
--- a/ci/scripts/image_scripts/configure_nameservers_centos.sh
+++ b/ci/scripts/image_scripts/configure_nameservers_centos.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Disable cloud-init network configuration that would overwrite the network config.
+cat <<EOF | sudo tee /etc/cloud/cloud.cfg.d/01-network.cfg
+network:
+  config: disabled
+# resolv.conf is managed by NetworkManager, cloud-init should not touch it
+manage_resolv_conf: false
+EOF
+# Even with the above, cloud-init will configure NetworkManager to not touch
+# resolv.conf *if* there is a nameserver configured for the subnet in openstack.
+# This is done in the following file, that we remove to let NM handle resolv.conf
+# Ref https://bugs.launchpad.net/cloud-init/+bug/1693251
+sudo rm /etc/NetworkManager/conf.d/99-cloud-init.conf || true
+sudo systemctl restart NetworkManager
+# Configure network (set nameservers, disable peer DNS and remove mac address
+# that was automatically added). The rest of the fields are kept as is.
+cat <<EOF | sudo tee /etc/sysconfig/network-scripts/ifcfg-eth0
+NAME="System eth0"
+BOOTPROTO=dhcp
+DEVICE=eth0
+MTU=1500
+ONBOOT=yes
+TYPE=Ethernet
+USERCTL=no
+PEERDNS=no
+DNS1=8.8.8.8
+DNS2=8.8.4.4
+EOF
+# Apply the changes
+sudo nmcli connection reload
+sudo nmcli connection up "System eth0"

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -17,36 +17,7 @@ export IMAGE_OS="${IMAGE_OS:-Centos}"
 export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-minikube}"
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
-# Disable cloud-init network configuration that would overwrite the network config.
-cat <<EOF | sudo tee /etc/cloud/cloud.cfg.d/01-network.cfg
-network:
-  config: disabled
-# resolv.conf is managed by NetworkManager, cloud-init should not touch it
-manage_resolv_conf: false
-EOF
-# Even with the above, cloud-init will configure NetworkManager to not touch
-# resolv.conf *if* there is a nameserver configured for the subnet in openstack.
-# This is done in the following file, that we remove to let NM handle resolv.conf
-# Ref https://bugs.launchpad.net/cloud-init/+bug/1693251
-sudo rm /etc/NetworkManager/conf.d/99-cloud-init.conf || true
-sudo systemctl restart NetworkManager
-# Configure network (set nameservers, disable peer DNS and remove mac address
-# that was automatically added). The rest of the fields are kept as is.
-cat <<EOF | sudo tee /etc/sysconfig/network-scripts/ifcfg-eth0
-NAME="System eth0"
-BOOTPROTO=dhcp
-DEVICE=eth0
-MTU=1500
-ONBOOT=yes
-TYPE=Ethernet
-USERCTL=no
-PEERDNS=no
-DNS1=8.8.8.8
-DNS2=8.8.4.4
-EOF
-# Apply the changes
-sudo nmcli connection reload
-sudo nmcli connection up "System eth0"
+"${SCRIPTS_DIR}"/configure_nameservers_centos.sh
 
 sudo dnf distro-sync -y
 sudo dnf update -y curl nss

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -8,10 +8,12 @@ export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.13.0"}
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+"${SCRIPTS_DIR}"/configure_nameservers_centos.sh
+
 # Install CRI-O
 "${SCRIPTS_DIR}"/install_crio_on_centos.sh
-# NOTE: When running with sudo, PATH is different. 
-# /usr/local/bin is NOT read by sudo commands, but rather /usr/bin. 
+# NOTE: When running with sudo, PATH is different.
+# /usr/local/bin is NOT read by sudo commands, but rather /usr/bin.
 sudo cp /usr/local/bin/crictl /usr/bin/
 
 echo $PATH|tr ':' '\n'


### PR DESCRIPTION
I totally missed that the node images didn't use the same script when I changed the cloud init. This should fix it.

The reason I didn't add these commands in the user-data, is that cloud-init itself is making network modifications, like disabling NetworkManager DNS. So instead of hoping that it goes in the correct order I think it is better like this.