### PR TITLE
Pre-pull more container images in node image

### DIFF
--- a/ci/scripts/image_scripts/target_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/target_cluster_container_images.sh
@@ -14,3 +14,6 @@ sudo systemctl enable --now crio
 for container in $(env | grep "CALICO_*" | cut -f2 -d'='); do
   sudo crictl pull "${container}"
 done
+
+# Pre-pull control-plane, kube-proxy and coredns images
+sudo /usr/local/bin/kubeadm config images pull --kubernetes-version=${KUBERNETES_VERSION}


### PR DESCRIPTION
Control-plane, etcd, kube-proxy and coredns can be pre-pulled to speed
up node provisioning and minimize network traffic.

This adds some unnecessary images for non-control-plane nodes. If this
is a concern, we could consider using separate images for workers and
control-plane nodes.