### PR TITLE
Fix packer template for node building

### DIFF
--- a/ci/images/gen_node_ubuntu_image.sh
+++ b/ci/images/gen_node_ubuntu_image.sh
@@ -22,7 +22,7 @@ export UBUNTU_VERSION=${UBUNTU_VERSION:-"20.04"}
 IMAGE_NAME="${CI_METAL3_IMAGE}-$(get_random_string 10)"
 FINAL_IMAGE_NAME=${FINAL_IMAGE_NAME:-"UBUNTU_""${UBUNTU_VERSION}""_NODE_IMAGE_K8S_""${KUBERNETES_VERSION}"}
 IMAGE_FLAVOR="1C-4GB-20GB"
-SOURCE_IMAGE="dba1e718-a102-46be-b8e9-ae1b1f2fd2fb"
+SOURCE_IMAGE_NAME="Ubuntu-20.04"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
 SSH_KEYPAIR_NAME="${CI_KEYPAIR_NAME}"
@@ -51,7 +51,7 @@ create_keypair "${CI_PUBLIC_KEY_FILE}" "${SSH_KEYPAIR_NAME}"
 # Build Image
 packer build \
   -var "image_name=${IMAGE_NAME}" \
-  -var "source_image=${SOURCE_IMAGE}" \
+  -var "source_image_name=${SOURCE_IMAGE_NAME}" \
   -var "user_data_file=${USER_DATA_FILE}" \
   -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
   -var "ssh_username=${SSH_USER_NAME}" \

--- a/ci/images/image_builder_template_node.json
+++ b/ci/images/image_builder_template_node.json
@@ -1,7 +1,7 @@
 {
     "variables": {
       "image_name": "",
-      "source_image": "4654e14c-f667-4e24-a538-c792b57c5bc8",
+      "source_image_name": "",
       "user_data_file": "userdata",
       "exec_script_path": "",
       "ssh_username": "metal3ci",
@@ -9,6 +9,7 @@
       "ssh_private_key_file": "",
       "network": "282a8c18-614c-4fbc-9928-b66d56ae3cbe",
       "floating_ip_net": "",
+      "reuse_ips": "false",
       "local_scripts_dir": "../scripts",
       "ssh_pty": "false",
       "flavor":"4C-16GB-50GB"
@@ -16,14 +17,14 @@
     "builders": [{
       "type": "openstack",
       "image_name": "{{user `image_name`}}",
-      "source_image": "{{user `source_image`}}",
+      "source_image_name": "{{user `source_image_name`}}",
       "user_data_file": "{{user `user_data_file`}}",
       "flavor":  "{{user `flavor`}}",
       "image_disk_format": "qcow2",
       "use_blockstorage_volume": "true",
       "volume_size": "20",
-      "reuse_ips": false,
-      "ssh_keypair_name": "metal3ci-key",
+      "reuse_ips": "{{user `reuse_ips`}}",
+      "ssh_keypair_name": "{{user `ssh_keypair_name`}}",
       "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
       "networks": "{{user `network`}}",
       "floating_ip_network": "{{user `floating_ip_net`}}",
@@ -45,4 +46,3 @@
       }
     ]
   }
-  


### PR DESCRIPTION
I missed updating the node template when I updated the metal3 template. This should fix the CentOS node image building pipeline.