### PR TITLE
Modify base image and docker installation scripts to accommodate Ubuntu 22.04 image building

### DIFF
--- a/ci/scripts/image_scripts/provision_base_image.sh
+++ b/ci/scripts/image_scripts/provision_base_image.sh
@@ -6,9 +6,15 @@ set -eux
 # to create a base image for our applications.
 
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
+# Needrestart and packer does not seem to work well together. Needrestart is
+# propmpting for what services to restart and packer cannot answer, so it get stuck.
+# This makes needrestart (l)ist the packages instead of prompting with a dialog.
+# The alternative would be sudo apt-get remove -y needrestart.
+echo '$nrconf{restart} = "l";' | sudo tee /etc/needrestart/needrestart.conf || true
+
 # Upgrade all packages
 sudo apt-get update
-sudo apt-get upgrade -f -y
+sudo apt-get dist-upgrade -f -y                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 
 # Install required packages.
 sudo apt install -y \

--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -9,9 +9,15 @@ export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.13.0"}
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
+# Needrestart and packer does not seem to work well together. Needrestart is
+# propmpting for what services to restart and packer cannot answer, so it get stuck.
+# This makes needrestart (l)ist the packages instead of prompting with a dialog.
+# The alternative would be sudo apt-get remove -y needrestart.
+echo '$nrconf{restart} = "l";' | sudo tee /etc/needrestart/needrestart.conf || true
+
 # Upgrade all packages
 sudo apt-get update
-sudo apt-get upgrade -f -y
+sudo apt-get dist-upgrade -f -y
 
 # Install required packages.
 sudo apt install -y \

--- a/ci/scripts/image_scripts/setup_docker_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_docker_ubuntu.sh
@@ -14,7 +14,7 @@ sudo add-apt-repository -y \
    $(lsb_release -cs) \
    stable"
 sudo apt-get update
-sudo apt-get install -y docker-ce=5:19.03.14~3-0~ubuntu-focal docker-ce-cli=5:19.03.14~3-0~ubuntu-focal containerd.io jq
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io jq
 sudo groupadd docker
 sudo usermod -aG docker "${USER}"
 sudo usermod -aG docker ubuntu


### PR DESCRIPTION
- sudo apt-get upgrade -f -y restarts the services and image building hangs so modifying needrestart  
-  docker-ce docker-ce-cli doesnt have the recommended version anymore for 22.04 so installing the latest. 

Co-authored-by: Lennart Jern lennart.jern@est.tech