### PR TITLE
Add workaround to solve the oslo-log issue

### DIFF
--- a/ci/scripts/image_scripts/build_ipa.sh
+++ b/ci/scripts/image_scripts/build_ipa.sh
@@ -52,6 +52,11 @@ git clone --single-branch --branch "${IPA_BUILDER_BRANCH}" "${IPA_BUILDER_REPO}"
 pushd "./ironic-python-agent-builder"
 git checkout "${IPA_BUILDER_COMMIT}"
 IPA_BUILDER_COMMIT="$(git rev-parse  HEAD)"
+
+# Handle oslo-log dependency issue, the issue is caused by a missmatch between
+# IPA dependency list and this https://opendev.org/openstack/requirements/src/branch/master/upper-constraints.txt
+sed -i '43i sed -i "s/oslo.log===5.0.0//" "$UPPER_CONSTRAINTS"' \
+    "${IPA_BUILD_WORKSPACE}/${IPA_BUILDER_PATH}/dib/ironic-python-agent-ramdisk/install.d/ironic-python-agent-ramdisk-source-install/60-ironic-python-agent-ramdisk-install"
 popd
 
 # Pull IPA repository to create IPA_IDENTIFIER


### PR DESCRIPTION
There was a missmatch between the "oslo-log" dependency required by
IPA and opendev.org/openstack/requirements/src/branch/master/upper-constraints.txt.