### PR TITLE
Add new ssh key for the CI and adding apt-get instead of apt

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -3,6 +3,7 @@ users:
   - name: ${DEFAULT_SSH_USER}
     ssh-authorized-keys:
       - ${SSH_AUTHORIZED_KEY}
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIpxfHuI2qfTYPrL4+thyHSS78Qj9ehp2/GYxuNXthgS estjorvas@est.tech"
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     groups: ${DEFAULT_SSH_USER_GROUP}
     shell: /bin/bash

--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -3,6 +3,7 @@ users:
   - name: ${DEFAULT_SSH_USER}
     ssh-authorized-keys:
       - ${SSH_AUTHORIZED_KEY}
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIpxfHuI2qfTYPrL4+thyHSS78Qj9ehp2/GYxuNXthgS estjorvas@est.tech"
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     groups: ${DEFAULT_SSH_USER_GROUP}
     shell: /bin/bash

--- a/ci/scripts/image_scripts/provision_base_image.sh
+++ b/ci/scripts/image_scripts/provision_base_image.sh
@@ -9,15 +9,17 @@ SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 # Needrestart and packer does not seem to work well together. Needrestart is
 # propmpting for what services to restart and packer cannot answer, so it get stuck.
 # This makes needrestart (l)ist the packages instead of prompting with a dialog.
+# It also makes it only print kernel hints instead of prompting users to acknowledge.
 # The alternative would be sudo apt-get remove -y needrestart.
-echo '$nrconf{restart} = "l";' | sudo tee /etc/needrestart/needrestart.conf || true
+echo -e '$nrconf{restart} = "l";\n$nrconf{kernelhints} = -1;' | sudo tee /etc/needrestart/needrestart.conf || true
 
 # Upgrade all packages
 sudo apt-get update
-sudo apt-get dist-upgrade -f -y                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+sudo apt-get dist-upgrade -f -y
 
 # Install required packages.
-sudo apt install -y \
+sudo apt-get update
+sudo apt-get install -y \
   vim \
   jq \
   git \

--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -12,15 +12,17 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 # Needrestart and packer does not seem to work well together. Needrestart is
 # propmpting for what services to restart and packer cannot answer, so it get stuck.
 # This makes needrestart (l)ist the packages instead of prompting with a dialog.
+# It also makes it only print kernel hints instead of prompting users to aknowledge.
 # The alternative would be sudo apt-get remove -y needrestart.
-echo '$nrconf{restart} = "l";' | sudo tee /etc/needrestart/needrestart.conf || true
+echo -e '$nrconf{restart} = "l";\n$nrconf{kernelhints} = -1;' | sudo tee /etc/needrestart/needrestart.conf || true
 
 # Upgrade all packages
 sudo apt-get update
 sudo apt-get dist-upgrade -f -y
 
 # Install required packages.
-sudo apt install -y \
+sudo apt-get update
+sudo apt-get install -y \
   vim \
   jq \
   git \
@@ -38,14 +40,14 @@ sudo apt install -y \
 sudo mv $SCRIPTS_DIR/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo apt-get install -y conntrack socat
-sudo apt install net-tools gcc linux-headers-$(uname -r) bridge-utils -y
-sudo apt install -y keepalived && sudo systemctl stop keepalived
+sudo apt-get install net-tools gcc linux-headers-$(uname -r) bridge-utils -y
+sudo apt-get install -y keepalived && sudo systemctl stop keepalived
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo bash -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
-sudo apt update -y
+sudo apt-get update -y
 
 # Install CRI-O
-"${SCRIPTS_DIR}"/install_crio_on_ubuntu.sh 
+"${SCRIPTS_DIR}"/install_crio_on_ubuntu.sh
 
 echo  "Installing kubernetes binaries"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"


### PR DESCRIPTION
The new ssh key uses the ed25519 format which is more secure, should
give better performance and avoid some issues with newer OSes that are
disabling some RSA hashes.

I also included a couple of small changes to make the image build go through:

- Configure needsrestart to only print kernel hints (it was hanging waiting for user input)
- Run apt-get update after apt-get dist-upgrade. This seems to be necessary or else it cannot find the packages it is trying to install.
- Use apt-get instead of apt in more places (there are warnings about using apt in scripts).

I can move these small fixes to a separate PR if required. In that case we will need to merge it before this as I was unable to build the image without them.