### PR TITLE
Uplift IPA base image to centos 9 stream

### DIFF
--- a/ci/scripts/image_scripts/build_ipa.sh
+++ b/ci/scripts/image_scripts/build_ipa.sh
@@ -31,7 +31,7 @@ IPA_BUILDER_PATH="ironic-python-agent-builder"
 IPA_IMAGE_NAME="${IPA_IMAGE_NAME:-ironic-python-agent}"
 IPA_IMAGE_TAR="${IPA_IMAGE_NAME}.tar"
 IPA_BASE_OS="${IPA_BASE_OS:-centos}"
-IPA_BASE_OS_RELEASE="${IPA_BASE_OS_RELEASE:-8-stream}"
+IPA_BASE_OS_RELEASE="${IPA_BASE_OS_RELEASE:-9-stream}"
 IRONIC_SIZE_LIMIT_MB=500
 DEV_ENV_REPO_LOCATION="${DEV_ENV_REPO_LOCATION:-/tmp/dib/metal3-dev-env}"
 IMAGE_REGISTRY="registry.nordix.org"
@@ -97,7 +97,8 @@ ironic-python-agent-builder --output "${IPA_IMAGE_NAME}" \
     --elements-path="${CUSTOM_ELEMENTS}" \
     --element='dynamic-login' --element='journal-to-console' \
     --element='devuser' --element='openssh-server' \
-    --element='extra-hardware' --element='ipa-module-autoload' --verbose
+    --element='extra-hardware' --element='ipa-module-autoload' \
+    --element='ipa-add-buildinfo' --verbose
 
 # Deactivate the python virtual environment
 deactivate

--- a/ci/scripts/image_scripts/ipa_builder_elements/ipa-add-buildinfo/install.d/80-ipa-add-buildinfo
+++ b/ci/scripts/image_scripts/ipa_builder_elements/ipa-add-buildinfo/install.d/80-ipa-add-buildinfo
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+echo "This IPA was built by ESJ on $(date)." > /buildinfo.txt


### PR DESCRIPTION
This change was needed because centos 8 stream is slowly loosing upstream support and
the systemd packaged with centos 8 stream had a bug that affected udev thus the inspection
and provisioning process of Ironic.

This change also contains a additional element that puts a buildinfo file into IPA to
help with future debugging tasks.