### PR TITLE
Disable kvm tdp_mmu to fix kernel crush issue

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -12,3 +12,6 @@ runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
   - update-crypto-policies --set LEGACY
   - systemctl restart sshd.service
+  - modprobe -r -a kvm_intel kvm
+  - modprobe kvm tdp_mmu=0
+  - modprobe -a kvm kvm_intel

--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -12,3 +12,6 @@ runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
   - echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
   - systemctl restart ssh.service
+  - modprobe -r -a kvm_intel kvm
+  - modprobe kvm tdp_mmu=0
+  - modprobe -a kvm kvm_intel


### PR DESCRIPTION
kvm tdp_mmu was enabled by default in the new kernels and started causing kernel crush in both centos and ubuntu. This PR disable it to fix this issue.
https://lore.kernel.org/lkml/20210726163106.1433600-1-pbonzini@redhat.com/