### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,22 @@
      "packageNames": ["kindest/node"],
      "automerge": false,
      "commitMessageTopic": "kindest/node"
+    },
+    {
+      "matchPackageNames": ["golang"],
+      "allowedVersions": "<=1.17"
+    },
+    {
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "allowedVersions": "<=1.23"
+    },
+    {
+      "matchPackageNames": ["kindest/node"],
+      "allowedVersions": "<=1.23"
+    },
+    {
+      "matchPackageNames": ["kubernetes-sigs/cri-tools"],
+      "allowedVersions": "<=1.23"
     }
   ],
   "prHourlyLimit": 5,

--- a/renovate.json
+++ b/renovate.json
@@ -67,14 +67,11 @@
      "furkatgofurov7",
      "kashifest",
      "lentzi90",
-     "macaptain",
      "mboukhalfa",
-     "namnx228",
      "Rozzii",
      "smoshiur1237",
      "Sunnatillo",
-     "Xenwar",
-     "ren-yifei"
+     "adilGhaffarDev"
    ],
    "assigneesSampleSize": 2
  }


### PR DESCRIPTION
This PR updates renovate configuration to monitor patch versions only since we need to uplift to minor versions manually after tests. Also updating the reviewers list here. 