### PR TITLE
Increase flavor disk size to 50GB

### DIFF
--- a/ci/images/image_builder_template.json
+++ b/ci/images/image_builder_template.json
@@ -12,7 +12,7 @@
     "reuse_ips": "false",
     "local_scripts_dir": "../scripts",
     "ssh_pty": "false",
-    "flavor":"2C-16GB-20GB"
+    "flavor":"2C-16GB-50GB"
   },
   "builders": [{
     "type": "openstack",


### PR DESCRIPTION
Curenntly image building is failing with no space issue. This PR will increase the disk size to tackle that problem.