### PR TITLE
downgrade Ubuntu version in image building

### DIFF
--- a/ci/images/gen_base_ubuntu_image.sh
+++ b/ci/images/gen_base_ubuntu_image.sh
@@ -18,7 +18,7 @@ source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_BASE_IMAGE}-$(get_random_string 10)"
 FINAL_IMAGE_NAME="${CI_BASE_IMAGE}"
-SOURCE_IMAGE_NAME="ubuntu-22.04-server-cloudimg-amd64"
+SOURCE_IMAGE_NAME="Ubuntu-20.04"
 IMAGE_FLAVOR="1C-4GB-20GB"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"


### PR DESCRIPTION
There were  some repository update issues during baseimage building
with ubuntu 22 so it needed to be downgraded.