### PR TITLE
align container image base with other images

### DIFF
--- a/resources/docker/workspace/Dockerfile
+++ b/resources/docker/workspace/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 # Install the minimum dependencies
 # (software-properties-common for add-apt-repository)


### PR DESCRIPTION
Ubuntu 20.04 is used everywhere else in the repository thus it has
been decided that this should be aligned too.