### PR TITLE
Rename var.sh to devtoolsvars.sh for dev tools integration tests

### DIFF
--- a/ci/jobs/metal3_dev_tools_integration_tests.pipeline
+++ b/ci/jobs/metal3_dev_tools_integration_tests.pipeline
@@ -50,7 +50,7 @@ pipeline {
     TESTS_FOR="${TESTS_FOR}"
     IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/metal3/images/temp/"
     DST_FOLDER="metal3/images/temp"
-    FINAL_IMAGE_NAME="${IMAGE_OS}_TEMP_IMG_${RAND_NAME}"
+    FINAL_IMAGE_NAME="${IMAGE_OS}_tmp_img_${RAND_NAME}"
     KUBERNETES_VERSION="${KUBERNETES_VERSION ?: 'v1.24.1' }"
 
     DOCKER_CMD_ENV="--env METAL3_CI_USER \
@@ -165,7 +165,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
           withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]) {
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
-              sh """  cat <<-EOF > "./jenkins/scripts/files/vars.sh"
+              sh """  cat <<-EOF > "./jenkins/scripts/files/devtoolsvars.sh"
                 IMAGE_LOCATION="${IMAGE_LOCATION}"
                 IMAGE_NAME="${FINAL_IMAGE_NAME}.qcow2"
                 KUBERNETES_VERSION="${KUBERNETES_VERSION}"


### PR DESCRIPTION
Fix for project-infra part is [here](https://github.com/metal3-io/project-infra/pull/428)

This PR fixes receiving IMAGE_NAME and IMAGE LOCATION variables from pipeline for metal3 dev tools integration tests. Metal3 dev tools integration tests are not using temporarily built node image, but default node image. Cause of the problem is IMAGE_NAME and iMAGE_LOCATION variables are not passed to the tests properly. This issue started appearing after we randomized the vars.sh file name [here](https://github.com/metal3-io/project-infra/blob/ef01400cb9c069290865fa01bd7e08b218c84499/jenkins/scripts/integration_test.sh#L129)