### PR TITLE
Install missing catatonit package

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -22,6 +22,7 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 sudo dnf distro-sync -y
 sudo dnf update -y curl nss
 sudo dnf install -y git make
+sudo dnf install -y podman-catatonit
 
 # Install EPEL repo (later required by atop, python3-bcrypt and python3-passlib)
 sudo dnf update -y && sudo dnf install -y epel-release


### PR DESCRIPTION
Openstack image building [job](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_openstack_image_building/312/execution/node/103/log/) failing to build metal3 centos image with the following

```
[0;32m    openstack: + sudo podman pod create -n ironic-pod[0m
[0;32m    openstack: Error: building local pause image: finding pause binary: exec: "catatonit": executable file not found in $PATH[0m
[0;32m    openstack: make: *** [Makefile:4: install_requirements] Error 125[0m
[1;32m==> openstack: Provisioning step had errors: Running the cleanup provisioner, if present...[0m
```

error. This should fix the missing package issue and survive the tests later on. 