### PR TITLE
Change node image network config to keyfile format in centos

### DIFF
--- a/ci/scripts/image_scripts/configure_nameservers_centos.sh
+++ b/ci/scripts/image_scripts/configure_nameservers_centos.sh
@@ -15,18 +15,25 @@ sudo rm /etc/NetworkManager/conf.d/99-cloud-init.conf || true
 sudo systemctl restart NetworkManager
 # Configure network (set nameservers, disable peer DNS and remove mac address
 # that was automatically added). The rest of the fields are kept as is.
-cat <<EOF | sudo tee /etc/sysconfig/network-scripts/ifcfg-eth0
-NAME="System eth0"
-BOOTPROTO=dhcp
-DEVICE=eth0
-MTU=1500
-ONBOOT=yes
-TYPE=Ethernet
-USERCTL=no
-PEERDNS=no
-DNS1=8.8.8.8
-DNS2=8.8.4.4
+cat <<EOF | sudo tee /etc/NetworkManager/system-connections/System-eth0.nmconnection
+[connection]
+id=System eth0
+type=ethernet
+interface-name=eth0
+autoconnect-priority=0
+
+[ethernet]
+mtu=1500
+
+[ipv4]
+dns=8.8.8.8;8.8.4.4;
+ignore-auto-dns=true
+method=auto
+
+[ipv6]
+method=ignore
 EOF
 # Apply the changes
+sudo chmod 600 /etc/NetworkManager/system-connections/System-eth0.nmconnection
 sudo nmcli connection reload
-sudo nmcli connection up "System eth0"
+sudo nmcli connection up 'System eth0'

--- a/ci/scripts/image_scripts/configure_network_centos.sh
+++ b/ci/scripts/image_scripts/configure_network_centos.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set NetworkManagers plugin to keyfile
+sudo sed -i 's/^plugins.*/plugins = keyfile/g' /etc/NetworkManager/NetworkManager.conf
+
 # Disable cloud-init network configuration that would overwrite the network config.
 cat <<EOF | sudo tee /etc/cloud/cloud.cfg.d/01-network.cfg
 network:

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -17,7 +17,7 @@ export IMAGE_OS="${IMAGE_OS:-Centos}"
 export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-minikube}"
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
-"${SCRIPTS_DIR}"/configure_nameservers_centos.sh
+"${SCRIPTS_DIR}"/configure_network_centos.sh
 
 sudo dnf distro-sync -y
 sudo dnf update -y curl nss

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -8,7 +8,7 @@ export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.14.0"}
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
-"${SCRIPTS_DIR}"/configure_nameservers_centos.sh
+"${SCRIPTS_DIR}"/configure_network_centos.sh
 
 # Install CRI-O
 "${SCRIPTS_DIR}"/install_crio_on_centos.sh


### PR DESCRIPTION
This PR solves issue of two connection profiles competing for eth0 interface. We set lower priority to System-eth0.nmconnection profile. 
The dev-env part of the solution is [here](https://github.com/metal3-io/metal3-dev-env/pull/1062)