### PR TITLE
Introduce fullstack build documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ integration_test: ## Run integration test
 	$(CURDIR)/ci/scripts/tests/integration_test.sh
 
 .PHONY: build_fullstack
-build_ipa:
+build_fullstack:
 	$(CURDIR)/ci/scripts/image_scripts/start_centos_fullstack_build.sh
 
 .PHONY: clean_fullstack_builder_vm


### PR DESCRIPTION
This commit does two things.

1. Aligns the old IPA-IRONIC build documentation with the logic of the fullstack job.

2. Fixes a typo in the Makefile that blocked the fullstack build process.