### PR TITLE
Build IPA based on opendev upstream repository

### DIFF
--- a/ci/scripts/image_scripts/bmh-patch-long-serial.yaml
+++ b/ci/scripts/image_scripts/bmh-patch-long-serial.yaml
@@ -1,4 +1,0 @@
----
-spec:
-  rootDeviceHints:
-    serialNumber: 0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0

--- a/ci/scripts/image_scripts/start_centos_fullstack_build.sh
+++ b/ci/scripts/image_scripts/start_centos_fullstack_build.sh
@@ -45,7 +45,6 @@ scp \
   "${CI_DIR}/../harbor/harbor_utils.sh" \
   "${CI_DIR}/run_build_ironic.sh" \
   "${CI_DIR}/bmh-patch-short-serial.yaml" \
-  "${CI_DIR}/bmh-patch-long-serial.yaml" \
   "${METAL3_CI_USER}@${BUILDER_IP}:/tmp/" > /dev/null
 
 # Send IPA builder custom element to remote executer


### PR DESCRIPTION
As https://review.opendev.org/c/openstack/ironic-python-agent/+/855866 
has been merged there is no need to use the custom fix from the Nordix branch.

This change also adds:
- customization options for running the full-stack build outside of the Metal3 CI
- customization options for adding and configuring user for IPA