### PR TITLE
🐛 Exclude NetworkManager upgrades

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -10,3 +10,4 @@ users:
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
   - sed -i 's/#Storage.*/Storage=persistent/' /etc/systemd/journald.conf
+  - echo exclude=NetworkManager* >> /etc/yum.conf


### PR DESCRIPTION
A workaround to the issue of losing ssh connection after creating a bridge 