### PR TITLE
CI: Add METAL3_CI_USER_KEY mount in all builds

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -120,6 +120,7 @@ pipeline {
                   sh "docker run --rm \
                     ${DOCKER_CMD_ENV}\
                     -v ${CURRENT_DIR}:/data \
+                    -v ${METAL3_CI_USER_KEY}=/data/id_ed25519_metal3ci \
                     registry.nordix.org/metal3/image-builder \
                     /data/ci/images/gen_jumphost_jenkins_ubuntu_image.sh \
                     /data/id_ed25519_metal3ci 1"
@@ -163,6 +164,7 @@ pipeline {
                   sh "docker run --rm \
                     ${DOCKER_CMD_ENV}\
                     -v ${CURRENT_DIR}:/data \
+                    -v ${METAL3_CI_USER_KEY}=/data/id_ed25519_metal3ci \
                     registry.nordix.org/metal3/image-builder \
                     /data/ci/images/gen_metal3_${IMAGE_OS.toLowerCase()}_image.sh \
                     /data/id_ed25519_metal3ci 1 \


### PR DESCRIPTION
The mounts seem to be needed at all times.