### PR TITLE
Configure nameservers for the metal3 ubuntu image

### DIFF
--- a/ci/images/README.md
+++ b/ci/images/README.md
@@ -94,6 +94,7 @@ It allows overriding many variables so it should be easy to customize to your ne
 
 This is how you use it:
 
+0. Create an ssh key using `ssh-keygen` if you don't have one already and add it to openstack: `openstack keypair create --public-key /path/to/key <name>`.
 1. Check the comments and variables at the top of `run_local.sh` and determine what you want/need to override.
 2. Create a file with your custom variables.
 3. Get an openstack.rc file with credentials to the cloud you want to build in.

--- a/ci/scripts/image_scripts/configure_network_ubuntu.sh
+++ b/ci/scripts/image_scripts/configure_network_ubuntu.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Configure network (set nameservers and disable peer DNS).
+cat <<EOF | sudo tee /etc/netplan/90-nameservers.yaml
+network:
+  version: 2
+  ethernets:
+    ens3:
+      dhcp4-overrides:
+        use-dns: no
+      nameservers:
+        addresses: [1.1.1.1, 1.0.0.1]
+
+EOF
+# Apply the changes
+sudo netplan apply

--- a/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
@@ -28,6 +28,8 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 export IMAGE_OS="${IMAGE_OS:-Ubuntu}"
 export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-kind}"
 
+"${SCRIPTS_DIR}"/configure_network_ubuntu.sh
+
 #Install Operator SDK
 OSDK_RELEASE_VERSION=v0.19.0
 curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OSDK_RELEASE_VERSION}/operator-sdk-${OSDK_RELEASE_VERSION}-x86_64-linux-gnu


### PR DESCRIPTION
Testing cloudflare DNS here. On centos we use google. Any of them should be better than the uncertainty and unreliability due to the DHCP added nameservers in openstack.

Also updated docs to explain how to create an openstack keypair.