### PR TITLE
Use apt-get instead of apt in scripts

### DIFF
--- a/ci/jobs/linter_tests.pipeline
+++ b/ci/jobs/linter_tests.pipeline
@@ -54,7 +54,7 @@ pipeline {
       }
       steps {
 
-        sh 'sudo apt install -y make'
+        sh 'sudo apt-get install -y make'
         sh 'make build-lint-md'
         sh 'make build-lint-go'
       }

--- a/ci/scripts/image_scripts/build_ipa.sh
+++ b/ci/scripts/image_scripts/build_ipa.sh
@@ -65,7 +65,7 @@ STAGING="${STAGING:-false}"
 METADATA_PATH="/tmp/metadata.txt"
 
 # Install required packages
-sudo apt install --yes python3-pip python3-virtualenv qemu-utils
+sudo apt-get install --yes python3-pip python3-virtualenv qemu-utils
 
 # Create the work directory
 mkdir --parents "${IPA_BUILD_WORKSPACE}"

--- a/ci/scripts/image_scripts/provision_jumphost_jenkins_base_img.sh
+++ b/ci/scripts/image_scripts/provision_jumphost_jenkins_base_img.sh
@@ -8,7 +8,7 @@ set -eux
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 
 # Install required packages.
-sudo apt install -y \
+sudo apt-get install -y \
   openjdk-8-jre \
   python3-pip
 

--- a/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
@@ -30,7 +30,7 @@ export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-kind}"
 
 "${SCRIPTS_DIR}"/configure_network_ubuntu.sh
 
-sudo apt install -y git
+sudo apt-get install -y git
 
 ## Install metal3 requirements
 mkdir -p "${M3_DENV_ROOT}"

--- a/ci/scripts/image_scripts/run_build_ironic.sh
+++ b/ci/scripts/image_scripts/run_build_ironic.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-sudo apt update -y
+sudo apt-get update -y
 # This script relies on upstream https://github.com/metal3-io/ironic-image/blob/main/patch-image.sh
 # to build Ironic container image based on a gerrit refspec of a patch.
 # Required parameter is REFSPEC, which is gerrit refspec of the patch

--- a/ci/scripts/image_scripts/setup_chrony_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_chrony_ubuntu.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-sudo apt install -y chrony
+sudo apt-get install -y chrony
 sudo chronyc -a 'burst 4/4' && sudo chronyc -a makestep
 sudo systemctl enable chrony
 sudo systemctl start chrony

--- a/ci/scripts/image_scripts/setup_qemu_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_qemu_ubuntu.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-sudo apt install -y qemu qemu-kvm
+sudo apt-get install -y qemu qemu-kvm
 
 # Enable nested virtualization
 sudo bash -c 'cat << EOF > /etc/modprobe.d/qemu-system-x86.conf

--- a/scripts/run_metal3_vm.sh
+++ b/scripts/run_metal3_vm.sh
@@ -33,7 +33,7 @@ if [[ ! -f "$WORK_DIR/ubuntu_metal3_vm.qcow2" ]] || [[ $vm_defined != *"ubuntu-m
 
   echo "Creating config ISO"
   # Install this package to generate iso from qcow2 file
-  sudo apt install  -y cloud-utils
+  sudo apt-get install -y cloud-utils
   # Create file iso
   sudo rm "$WORK_DIR/config.iso" || true
   cloud-localds "$WORK_DIR/ubuntu-metal3-config.iso" "$WORK_DIR/ubuntu-metal3-config.yaml"

--- a/tools/setup_machines/providers/kinder/setup_test_environment.sh
+++ b/tools/setup_machines/providers/kinder/setup_test_environment.sh
@@ -28,7 +28,7 @@ fi
 # Install utility binaries on machines, Eg. net-tools
 machines=$(kinder get nodes --name "${cluster_name}")
 for machine in ${machines}; do
-    docker exec "${machine}" bash -c 'apt update -y;apt install -y tree vim net-tools mlocate iputils-ping'
+    docker exec "${machine}" bash -c 'apt-get update -y; apt-get install -y tree vim net-tools mlocate iputils-ping'
 done
 
 # Remove existing and create more control plane networks


### PR DESCRIPTION
Apt does not have stable CLI, and gives out warnings when used from script context. Replace apt with apt-get.