### PR TITLE
Add element in IPA finalise stage to cleanup dracut*

### DIFF
--- a/ci/scripts/image_scripts/build_ipa.sh
+++ b/ci/scripts/image_scripts/build_ipa.sh
@@ -130,7 +130,7 @@ ironic-python-agent-builder --output "${IPA_IMAGE_NAME}" \
     --element='dynamic-login' --element='journal-to-console' \
     --element='devuser' --element='openssh-server' \
     --element='extra-hardware' --element='ipa-module-autoload' \
-    --element='ipa-add-buildinfo' --verbose
+    --element='ipa-add-buildinfo' --element='ipa-cleanup-dracut' --verbose
 
 # Deactivate the python virtual environment
 deactivate

--- a/ci/scripts/image_scripts/ipa_builder_elements/ipa-cleanup-dracut/cleanup.d/99-ipa-cleanup-dracut
+++ b/ci/scripts/image_scripts/ipa_builder_elements/ipa-cleanup-dracut/cleanup.d/99-ipa-cleanup-dracut
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+sudo rm -rf "$TARGET_ROOT/var/tmp/dracut"*


### PR DESCRIPTION
The IPA image size has grown to more than 800mb which limits the requirement for the image size.  It seems that there are three dracut.* directories present in the image which has 181Mb size each. So adding this directory cleanup element in our IPA building image. 