### PR TITLE
Fixes bnx2x firmware issue with NIC

### DIFF
--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -50,6 +50,8 @@ sudo dnf install device-mapper-persistent-data lvm2 -y
 sudo yum downgrade -y NetworkManager-1.40.0-1.el9
 sudo systemctl restart NetworkManager
 
+# Fixes bnx2x firmware issue with NIC (reported here https://bugzilla.redhat.com/show_bug.cgi?id=1952463)
+sudo yum install linux-firmware -y
 
 # Disable SELINUX enforcing
 sudo sed -i 's/enforcing/disabled/g' /etc/selinux/config /etc/selinux/config


### PR DESCRIPTION
Current Centos9 version we are using have an issue with bnx2x firmware. It is blocking NIC from coming up in BML tests. This PR fixes the issue