### PR TITLE
add support for custom config-drive in IPA part 1

### DIFF
--- a/ci/scripts/image_scripts/build_ipa.sh
+++ b/ci/scripts/image_scripts/build_ipa.sh
@@ -115,6 +115,9 @@ fi
 if [ "${ENABLE_DEV_USER_SSH}" == "true" ]; then
 export DIB_DEV_USER_AUTHORIZED_KEYS="${DEV_USER_SSH_PATH}"
 fi
+export DIB_INSTALLTYPE_simple_init="repo"
+export DIB_REPOLOCATION_glean="https://github.com/Nordix/glean.git"
+export DIB_REPOREF_glean="refs/heads/extend_label_support"
 
 # IPA builder customisation variables
 # Path to custom IPA builder kernel module element
@@ -130,7 +133,8 @@ ironic-python-agent-builder --output "${IPA_IMAGE_NAME}" \
     --element='dynamic-login' --element='journal-to-console' \
     --element='devuser' --element='openssh-server' \
     --element='extra-hardware' --element='ipa-module-autoload' \
-    --element='ipa-add-buildinfo' --element='ipa-cleanup-dracut' --verbose
+    --element='ipa-add-buildinfo' --element='ipa-cleanup-dracut' \
+    --element='simple-init' --element='override-simple-init' --verbose
 
 # Deactivate the python virtual environment
 deactivate

--- a/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/environment.d/99-override-simple-init
+++ b/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/environment.d/99-override-simple-init
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export DIB_SIMPLE_INIT_CONFIG_DRIVE_LABEL="${DIB_SIMPLE_INIT_CONFIG_DRIVE_LABEL:-ir-vfd-dev}"
+

--- a/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/post-install.d/99-override-simple-init
+++ b/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/post-install.d/99-override-simple-init
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+if [ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]; then
+    set -x
+fi
+
+SCRIPTDIR=$(dirname "$0")
+
+SEDSTRING="s/Environment=/Environment=\"GLEAN_CONFIG_DRIVE_LABEL=${DIB_SIMPLE_INIT_CONFIG_DRIVE_LABEL}\"/"
+
+sed -e "${SEDSTRING}" "${SCRIPTDIR}/glean-early-override-template.service" > "/etc/systemd/system/glean-early.service"
+

--- a/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/post-install.d/glean-early-override-template.service
+++ b/ci/scripts/image_scripts/ipa_builder_elements/override-simple-init/post-install.d/glean-early-override-template.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Early glean execution
+Before=network-pre.target
+Wants=network-pre.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/glean/lib64/python3.9/site-packages/glean/init/glean-early.sh --debug
+RemainAfterExit=true
+
+StandardOutput=journal+console
+Environment=
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This commit is the part of a series of commits
that introduces new features to the IPA image in order to support various dhcpless use-cases.

This commit introduces the following:

- simple-init element using modified glean from fork
- simple-init now supports custom block device label when looking for the network_info.json