### PR TITLE
fix run_local image builder script

### DIFF
--- a/ci/images/README.md
+++ b/ci/images/README.md
@@ -105,14 +105,16 @@ Here is an example of custom variables:
 
 ```bash
 # My custom variables
-export SSH_USER_NAME="foo"
-export SSH_USER_GROUP="wheel"
-export SSH_KEYPAIR_NAME="foo-key"
-export SSH_PUBLIC_KEY_FILE="/home/foo/.ssh/id_rsa.pub"
-export SSH_PRIVATE_KEY_FILE="/home/foo/.ssh/id_rsa"
+export PACKER_SSH_USER_NAME="foo"
+export USERDATA_SSH_PUBLIC_KEY_FILE="/home/foo/.ssh/id_rsa.pub"
+export PACKER_SSH_PRIVATE_KEY_FILE="/home/foo/.ssh/id_rsa"
 export IMAGE_NAME="foo-test-image"
 export SOURCE_IMAGE_NAME="Upstream-centos-or-ubuntu"
-export NETWORK="abcdefg"
+# Openstack network name, vm will receive Openstack internal IP from this network.
+export OS_NETWORK_NAME="ext-net"
+# If user wants to use Openstack network ID instead of the network name,
+# then this variable can be set this instead (then network ID lookup won't happen):
+export OS_NETWORK_ID="abcdefg"
 # Artifactory variables
 # These are needed if you want to build Node images and upload them to Artifactory
 export RT_URL="https://artifactory.nordix.org/artifactory"
@@ -123,6 +125,19 @@ export RT_TOKEN=<your-token>
 **NOTE:** The script uploads the node images (i.e. those produced by `provision_node_image_ubuntu.sh` and `provision_node_image_centos.sh`) to Artifactory.
 Make sure you use an image name that does not conflict with existing images!
 This is also a good idea for other images since they will end up in Openstack.
+
+Additional configuration options:
+```bash
+export PACKER_DEBUG_ENABLED="true/false" # if true runs the packer build in interactive debug mode,
+                                         # packer stops between build stages
+export IMAGE_CLEANUP="true/false" # if true deletes the image from openstack that has an equivalent
+                                  # name with the one specifed in the IMAGE_NAME variable, if false doesn't delete any image,
+                                  # instead appends a timestamp to the name of each newly built image to avoid collision
+```
+
+If the the `./run_local sandbox` command is issued the packer build and the artifactory upload process
+won't be executed, rather the user will be presented with an interactive container environment where
+the openstack cli can be used to check the openstack resources.
 
 And here is how to use it:
 

--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -1,12 +1,12 @@
 #cloud-config
 users:
-  - name: ${DEFAULT_SSH_USER}
+  - name: ${USERDATA_SSH_USER}
     ssh-authorized-keys:
-      - ${SSH_AUTHORIZED_KEY}
+      - ${USERDATA_SSH_AUTHORIZED_KEY}
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-    groups: ${DEFAULT_SSH_USER_GROUP}
+    groups: ${USERDATA_SSH_USER_GROUP}
     shell: /bin/bash
 
 runcmd:
-  - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
+  - sed -i "/^127.0.0.1/ s/$/ ${USERDATA_HOSTNAME}/" /etc/hosts
   - sed -i 's/#Storage.*/Storage=persistent/' /etc/systemd/journald.conf

--- a/ci/images/run_local.sh
+++ b/ci/images/run_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script can be used to run locally one of the image building
 # scripts. It reproduces the CI environment.
@@ -20,118 +20,160 @@ set -eux
 PROVISIONING_SCRIPT="${1:?}"
 
 #
-# Required variables:
-#
-# - SSH_KEYPAIR_NAME: Name of the keypair in openstack
-
-#
 # Overridable variables
 #
 # These variables can be overridden by the user, but have defaults that may or
 # may not be useful.
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
-SSH_USER_NAME="${SSH_USER_NAME:-${USER}}"
-SSH_PUBLIC_KEY_FILE="${SSH_PUBLIC_KEY_FILE:-/home/${USER}/.ssh/id_rsa.pub}"
-SSH_PRIVATE_KEY_FILE="${SSH_PRIVATE_KEY_FILE:-/home/${USER}/.ssh/id_rsa}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.26.0}"
+# ssh user name used by packer for provisioning
+PACKER_SSH_USER_NAME="${PACKER_SSH_USER_NAME:-${USER}}"
+# ssh username injected to the userdata files (could differ from what packer is using)
+USERDATA_SSH_USER_NAME="${USERDATA_SSH_USER_NAME:-${PACKER_SSH_USER_NAME}}"
+USERDATA_SSH_PUBLIC_KEY_FILE="${USERDATA_SSH_PUBLIC_KEY_FILE:-/home/${USER}/.ssh/id_rsa.pub}"
+PACKER_SSH_PRIVATE_KEY_FILE="${PACKER_SSH_PRIVATE_KEY_FILE:-/home/${USER}/.ssh/id_rsa}"
 IMAGE_NAME="${IMAGE_NAME:-${USER}-test}"
 # Image to start build from. For example ubuntu-22.04-server-cloudimg-amd64 or CentOS-Stream-9-20220829
-SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-CentOS-Stream-GenericCloud-8}"
+SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-CentOS-Stream-GenericCloud-9}"
 # Group to add user to. To get sudo access on CentOS: wheel, on Ubuntu: sudo
-SSH_USER_GROUP="${SSH_USER_GROUP:-wheel}"
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.26.0"}
-# The network name is by defualt set to $DEV_EXT_NET. You can override it here.
-NETWORK_NAME=""
-# Or if you want to use ID, set this instead:
-# NETWORK=<ID-of-network>
+USERDATA_SSH_USER_GROUP="${USERDATA_SSH_USER_GROUP:-wheel}"
+# Openstack network name, vm will receive Openstack internal IP from this network.
+OS_NETWORK_NAME="${OS_NETWORK_NAME:-}"
+# Or if you want to use Openstack network ID instead of the network name set this instead
+# (then network ID lookup won't happen):
+OS_NETWORK_ID="${OS_NETWORK_ID:-}"
+# IMAGE_DATE is used to distinguish between images because the openstack client
+# can't download an image if there are multiple images present in OS with the same name
+IMAGE_DATE="$(date +"%Y-%m-%dT%H-%M-%S%z")"
+PACKER_DEBUG_ENABLED="${PACKER_DEBUG_ENABLED:-false}"
+PACKER_BUILD_COMMAND=("build")
+PACKER_INTERACTIVE=("--rm")
+IMAGE_CLEANUP="${IMAGE_CLEANUP:-false}"
+
+
+if [ "${PACKER_DEBUG_ENABLED}" = "true" ]; then
+  PACKER_BUILD_COMMAND=("build" "-debug")
+  PACKER_INTERACTIVE=("--rm" "-ti")
+fi
 
 # The variables below should not need to be touched by the user
-if [[ "$PROVISIONING_SCRIPT" == *"node"* ]]; then
+if [[ "${PROVISIONING_SCRIPT}" == *"node"* ]]; then
   BUILDER_CONFIG_FILE="image_builder_template_node.json"
   IMAGE_FLAVOR="1C-4GB-20GB"
-elif [[ "$PROVISIONING_SCRIPT" == *"metal3"* ]]; then
+elif [[ "${PROVISIONING_SCRIPT}" == *"metal3"* ]]; then
   BUILDER_CONFIG_FILE="image_builder_template.json"
   IMAGE_FLAVOR="4C-16GB-50GB"
-elif [[ "$PROVISIONING_SCRIPT" == *"base"* ]]; then
+elif [[ "${PROVISIONING_SCRIPT}" == *"base"* ]]; then
   BUILDER_CONFIG_FILE="image_builder_template.json"
   IMAGE_FLAVOR="1C-4GB-20GB"
+elif [ "${PROVISIONING_SCRIPT}" = "sandbox" ]; then
+  echo "Local builder script will run in sandbox mode!"
 else
   echo "Available provisioning scripts are:"
   find ../scripts/image_scripts/provision_* | cut -f4 -d'/'
   exit 1
 fi
 
-if [[ "$PROVISIONING_SCRIPT" == *"centos"* ]]; then
+if [[ "${PROVISIONING_SCRIPT}" == *"centos"* ]]; then
   USER_DATA_TEMPLATE="centos_userdata.tpl"
 else
   USER_DATA_TEMPLATE="ubuntu_userdata.tpl"
 fi
 
 DEV_TOOLS="$(dirname "$(readlink -f "${0}")")/../../"
-SCRIPTS_DIR="${DEV_TOOLS}/ci/scripts/image_scripts"
 OS_SCRIPTS_DIR="${DEV_TOOLS}/ci/scripts/openstack"
 IMAGES_DIR="${DEV_TOOLS}/ci/images"
 
-# shellcheck source=ci/scripts/openstack/infra_defines.sh
-source "${OS_SCRIPTS_DIR}/infra_defines.sh"
+CR_CMD_ENV=(
+  "--env" "OS_AUTH_URL"
+  "--env" "OS_USER_DOMAIN_NAME"
+  "--env" "OS_PROJECT_DOMAIN_NAME"
+  "--env" "OS_REGION_NAME"
+  "--env" "OS_PROJECT_NAME"
+  "--env" "OS_TENANT_NAME"
+  "--env" "OS_AUTH_VERSION"
+  "--env" "OS_IDENTITY_API_VERSION"
+  "--env" "OS_USERNAME"
+  "--env" "OS_PASSWORD"
+)
+
+
+if [ "${PROVISIONING_SCRIPT}" = "sandbox" ]; then
+  "${CONTAINER_RUNTIME}" run --rm -ti \
+    "${CR_CMD_ENV[@]}" \
+    "-v" "${DEV_TOOLS}:/data/metal3-dev-tools" \
+    "-v" "/tmp:/tmp" \
+    "registry.nordix.org/metal3/image-builder" \
+    "/bin/bash"
+  exit 0
+fi
+
+# Image name timestamp appending or cleanup based on config
+if [ "${IMAGE_CLEANUP}" = "true" ]; then
+  FULL_IMAGE_NAME="${IMAGE_NAME}"
+  "${CONTAINER_RUNTIME}" run --rm \
+    "${CR_CMD_ENV[@]}" \
+    "registry.nordix.org/metal3/image-builder" \
+    bash -c "openstack image delete ${FULL_IMAGE_NAME} || true"
+else
+  FULL_IMAGE_NAME="${IMAGE_NAME}-${IMAGE_DATE}"
+fi
+
+# Paths inside the container
+CONTAINER_OS_UTILS="/data/metal3-dev-tools/ci/scripts/openstack/utils.sh"
+
+# The network where the vm will get it's floating ip (external IP)
+FLOATING_IP_NETWORK="ext-net"
+REUSE_IPS="true"
+# If NETWORK is not set directly, try to get it based on NETWORK_NAME.
+if [ -z "${OS_NETWORK_ID}" ]; then
+  OS_NETWORK_ID=$("${CONTAINER_RUNTIME}" run --rm \
+            "${CR_CMD_ENV[@]}" \
+	    "-v" "${DEV_TOOLS}":"/data/metal3-dev-tools" \
+	    "registry.nordix.org/metal3/image-builder" \
+            bash -c "source ${CONTAINER_OS_UTILS} && get_resource_id_from_name network ${OS_NETWORK_NAME}")
+fi
+
+# Generate user data and provision command
+
 # shellcheck source=ci/scripts/openstack/utils.sh
 source "${OS_SCRIPTS_DIR}/utils.sh"
-
-NETWORK_NAME="${NETWORK_NAME:-${DEV_EXT_NET}}"
-FLOATING_IP_NETWORK="${EXT_NET}"
-REUSE_IPS="true"
-# get_resource_id_from_name assumes that the openstack CLI is installed locally.
-# If this is not the case, set the NETWORK directly instead.
-NETWORK="${NETWORK:-$(get_resource_id_from_name network "${NETWORK_NAME}")}"
 
 TMP="$(mktemp -d)"
 USER_DATA_FILE="${TMP}/userdata"
 STARTER_SCRIPT_PATH="${TMP}/build_starter.sh"
 
-REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/${PROVISIONING_SCRIPT}"
+REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${PACKER_SSH_USER_NAME}/image_scripts/${PROVISIONING_SCRIPT}"
 echo "${REMOTE_EXEC_CMD}" > "${STARTER_SCRIPT_PATH}"
 
-SSH_AUTHORIZED_KEY="$(cat "${SSH_PUBLIC_KEY_FILE}")"
+USERDATA_SSH_AUTHORIZED_KEY="$(cat "${USERDATA_SSH_PUBLIC_KEY_FILE}")"
 render_user_data \
-  "${SSH_AUTHORIZED_KEY}" \
-  "${SSH_USER_NAME}" \
-  "${SSH_USER_GROUP}" \
+  "${USERDATA_SSH_AUTHORIZED_KEY}" \
+  "${USERDATA_SSH_USER_NAME}" \
+  "${USERDATA_SSH_USER_GROUP}" \
   "${IMAGE_NAME}" \
   "${IMAGES_DIR}/${USER_DATA_TEMPLATE}" \
   "${USER_DATA_FILE}"
-
-CR_CMD_ENV="--env METAL3_CI_USER \
-  --env METAL3_CI_USER_KEY=/data/id_ed25519_metal3ci \
-  --env OS_AUTH_URL \
-  --env OS_USER_DOMAIN_NAME \
-  --env OS_PROJECT_DOMAIN_NAME \
-  --env OS_REGION_NAME \
-  --env OS_PROJECT_NAME \
-  --env OS_TENANT_NAME \
-  --env OS_AUTH_VERSION \
-  --env OS_IDENTITY_API_VERSION \
-  --env OS_USERNAME \
-  --env OS_PASSWORD "
 
 # Paths inside the container
 CONTAINER_SCRIPTS_DIR="/data/metal3-dev-tools/ci/scripts/image_scripts"
 CONTAINER_IMAGES_DIR="/data/metal3-dev-tools/ci/images"
 
-# Run the script in a docker container
-"${CONTAINER_RUNTIME}" run --rm \
-  "${CR_CMD_ENV}"\
-  -v "${DEV_TOOLS}":/data/metal3-dev-tools \
-  -v "${SSH_PRIVATE_KEY_FILE}":/data/private_key \
+# Run the packer build in a docker container
+"${CONTAINER_RUNTIME}" run "${PACKER_INTERACTIVE[@]}" \
+  "${CR_CMD_ENV[@]}" \
+  -v "${DEV_TOOLS}":"/data/metal3-dev-tools" \
+  -v "${PACKER_SSH_PRIVATE_KEY_FILE}":"/data/private_key" \
   -v "${TMP}":"${TMP}" \
-  registry.nordix.org/metal3/image-builder \
-  packer build \
-    -var "image_name=${IMAGE_NAME}" \
+  "registry.nordix.org/metal3/image-builder" \
+  packer "${PACKER_BUILD_COMMAND[@]}" \
+    -var "image_name=${FULL_IMAGE_NAME}" \
     -var "source_image_name=${SOURCE_IMAGE_NAME}" \
     -var "user_data_file=${USER_DATA_FILE}" \
     -var "exec_script_path=${STARTER_SCRIPT_PATH}" \
-    -var "ssh_username=${SSH_USER_NAME}" \
-    -var "ssh_keypair_name=${SSH_KEYPAIR_NAME}" \
+    -var "ssh_username=${PACKER_SSH_USER_NAME}" \
     -var "ssh_private_key_file=/data/private_key" \
-    -var "network=${NETWORK}" \
+    -var "network=${OS_NETWORK_ID}" \
     -var "floating_ip_net=${FLOATING_IP_NETWORK}" \
     -var "reuse_ips=${REUSE_IPS}" \
     -var "local_scripts_dir=${CONTAINER_SCRIPTS_DIR}" \
@@ -139,8 +181,18 @@ CONTAINER_IMAGES_DIR="/data/metal3-dev-tools/ci/images"
     -var "flavor=${IMAGE_FLAVOR}" \
     "${CONTAINER_IMAGES_DIR}/${BUILDER_CONFIG_FILE}"
 
+if [[ "${PROVISIONING_SCRIPT}" == *"node"* ]]; then 
+  
+  CR_CMD_ENV+=(
+    "--env" "RT_URL"
+    "--env" "RT_USER"
+    "--env" "RT_TOKEN"
+)
 
-# upload node image to artifactory
-if [[ "$PROVISIONING_SCRIPT" == *"node"* ]]; then
-  bash "${SCRIPTS_DIR}/upload_node_image_rt.sh" "${IMAGE_NAME}"
+  "${CONTAINER_RUNTIME}" run --rm \
+    "${CR_CMD_ENV[@]}" \
+    -v "${DEV_TOOLS}:/data/metal3-dev-tools" \
+    -v "/tmp:/tmp" \
+    "registry.nordix.org/metal3/image-builder" \
+    bash "/data/metal3-dev-tools/ci/scripts/image_scripts/upload_node_image_rt.sh" "${FULL_IMAGE_NAME}"
 fi

--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -1,12 +1,12 @@
 #cloud-config
 users:
-  - name: ${DEFAULT_SSH_USER}
+  - name: ${USERDATA_SSH_USER}
     ssh-authorized-keys:
-      - ${SSH_AUTHORIZED_KEY}
+      - ${USERDATA_SSH_AUTHORIZED_KEY}
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-    groups: ${DEFAULT_SSH_USER_GROUP}
+    groups: ${USERDATA_SSH_USER_GROUP}
     shell: /bin/bash
 
 runcmd:
-  - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
+  - sed -i "/^127.0.0.1/ s/$/ ${USERDATA_HOSTNAME}/" /etc/hosts
   - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link

--- a/ci/scripts/openstack/utils.sh
+++ b/ci/scripts/openstack/utils.sh
@@ -81,10 +81,10 @@ render_user_data() {
 
   local IN_FILE OUT_FILE
 
-  export SSH_AUTHORIZED_KEY="${1:?}"
-  export DEFAULT_SSH_USER="${2:?}"
-  export DEFAULT_SSH_USER_GROUP="${3:?}"
-  export HOSTNAME="${4:?}"
+  export USERDATA_SSH_AUTHORIZED_KEY="${1:?}"
+  export USERDATA_SSH_USER="${2:?}"
+  export USERDATA_SSH_USER_GROUP="${3:?}"
+  export USERDATA_HOSTNAME="${4:?}"
   IN_FILE="${5:?}"
   OUT_FILE="${6:?}"
 


### PR DESCRIPTION
- fix failing parameter expension of the container env vars (this was caused by shellcheck related refactoring)

- remove unnecessary container env vars

- add timestamp to the generated image otherwise in case of

  subsequent image builds the openstack client won't be abel to distinguish between the images and won't save the new image

- introduce more explicit variable nameing in certain cases

- remove key_pair variable from the packer vars as it is not needed and just complicates the script

- restrict openstack related logic into the container, so nothing that talks to openstack will be executed outside the container thus there is no need to have the ostack client installed on the host system

- add sandbox mode, in case the user would like to look around in ostack without building an image

- add interactive debug mode for the packer building process, user can wait between packer build steps thus the build vm won't disappear in case of an issue

Co-authored-by: Lennart Jern lennart.jern@est.tech