### PR TITLE
Simplify repo sync scripts

### DIFF
--- a/scripts/update-nordix-repos-master.sh
+++ b/scripts/update-nordix-repos-master.sh
@@ -95,8 +95,6 @@ function update_custom_branch {
     do
         echo "Updating ${branch} branch in ${LOCAL_REPO}"
         git checkout "origin/${branch}"
-        git fetch "origin" "${branch}"
-        git rebase "origin/${branch}"
         git remote add "remote-${branch}" "${NORDIX_REPO}"
         git push -uf "remote-${branch}" "HEAD:refs/heads/${branch}"
         echo "Push done to ${branch} branch in ${NORDIX_REPO}"
@@ -136,9 +134,6 @@ do
     BRANCH=$(git rev-parse --abbrev-ref HEAD)
     echo "Updating ${BRANCH} branch in ${repo}"
     git checkout "${BRANCH}"
-    # origin points to upstream repos
-    git fetch origin
-    git rebase origin/"${BRANCH}"
     git remote add nordixrepo "${ndxarray[$i]}"
     git push -uf nordixrepo "${BRANCH}"
     echo "Push done to ${ndxarray[$i]}"


### PR DESCRIPTION
There is no need to fetch right after we cloned and there is no need to rebase since we are just syncing upstream changes to the fork.