### PR TITLE
Switch dev-tools integration pipeline to use dynamic workers

### DIFF
--- a/ci/jobs/metal3_dev_tools_integration_tests.pipeline
+++ b/ci/jobs/metal3_dev_tools_integration_tests.pipeline
@@ -19,7 +19,7 @@ script {
 }
 
 pipeline {
-  agent { label 'metal3-static-workers' }
+  agent { label 'metal3-workers' }
   options { ansiColor('xterm') }
   environment {
     METAL3_CI_USER="metal3ci"


### PR DESCRIPTION
This switches the dev-tools integration test pipeline to use dynamic jenkins workers instead of the old static workers that we have used so far. The idea is to ensure that the dynamic workers can be used without risking too much.