### PR TITLE
remove machine id in ubuntu images

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_ubuntu.sh
@@ -64,3 +64,6 @@ sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_confi
 
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh
+
+# Reset machine-id to regenerate on next boot.
+"${SCRIPTS_DIR}"/reset_machine_id.sh

--- a/ci/scripts/image_scripts/provision_node_image_ubuntu.sh
+++ b/ci/scripts/image_scripts/provision_node_image_ubuntu.sh
@@ -72,5 +72,8 @@ sudo rm "${HOME}"/.ssh/authorized_keys
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh
 
+# Reset machine-id to regenerate on next boot.
+"${SCRIPTS_DIR}"/reset_machine_id.sh
+
 # Remove the scripts
 sudo rm -r "${SCRIPTS_DIR}"

--- a/ci/scripts/image_scripts/reset-machine-id.sh
+++ b/ci/scripts/image_scripts/reset-machine-id.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+# This script will empty the /etc/machine-id (machine-id(5)
+# file so that the machine-id will be regenerated on the
+# next (initial) boot of the image
+
+sudo rm -f /etc/machine-id
+sudo touch /etc/machine-id


### PR DESCRIPTION
Copy of #675, #675 could not be tested due to CI constraints.
Authored by @jklippel

"Currently the image contains an id in /etc/machine-id. This file should contain a unique machine ID which uniquely identifies the host (see machine-id(5)).
Some processes rely on this file to generate other values e.g. mac-addresses on bond interfaces.
If the machine-id is the same accross many hosts
these mac-addresses will under certain circumstances be generated identically. Two hosts having the same mac address leads to L2-networking issues.

This commit empties the machine-id file so that it is regenerated on the next boot (which will be the first boot of the machine the image is used for)."
