### PR TITLE
Share metal3 image to dev2 project after successful build

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -152,6 +152,7 @@ pipeline {
               OS_AUTH_URL=os_auth_urls.get(env.REGION)
               OS_REGION_NAME=os_region_names.get(env.REGION)
               TEST_EXECUTER_VM_NAME = "${TEST_EXECUTER_VM_NAME}-${IMAGE_OS}-based"
+              IMAGE_OS="${IMAGE_OS}"
             }
             steps {
               echo 'Building Metal3 ${IMAGE_OS} image for ${REGION} region'
@@ -169,6 +170,20 @@ pipeline {
                     /data/ci/images/gen_metal3_${IMAGE_OS.toLowerCase()}_image.sh \
                     /data/id_ed25519_metal3ci 1 \
                     provision_metal3_image_${IMAGE_OS.toLowerCase()}.sh"
+                }
+              }
+            }
+          }
+        }
+        post{
+          success {
+            script {
+              if (REGION == 'Karlskrona') {
+                echo 'Share newly built image to dev2 project'
+                withCredentials([
+                  usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')
+                ]) {
+                    sh "/data/ci/scripts/image_scripts/share_image.sh"
                 }
               }
             }

--- a/ci/scripts/image_scripts/share_image.sh
+++ b/ci/scripts/image_scripts/share_image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eux
+
+export IMAGE_ID
+export PROJECT_ID
+
+OS_SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")/.."
+
+# shellcheck source=ci/scripts/openstack/infra_defines.sh
+. "${OS_SCRIPTS_DIR}/openstack/infra_defines.sh"
+
+# shellcheck source=ci/scripts/openstack/utils.sh
+. "${OS_SCRIPTS_DIR}/openstack/utils.sh"
+
+export IMAGE_OS="${IMAGE_OS:-}"
+
+if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
+  IMAGE_NAME=${CI_METAL3_IMAGE}
+elif [[ "${IMAGE_OS}" == "CentOS" ]]; then
+  IMAGE_NAME=${CI_METAL3_CENTOS_IMAGE}
+else
+  echo "error: Available IMAGE_OS variables are: CentOS and Ubuntu. Got: ${IMAGE_OS}"
+  exit 1
+fi
+
+# get image id
+IMAGE_ID="$(get_image_id "${IMAGE_NAME}")"
+# get project id
+PROJECT_ID="$(get_project_id "dev2")"
+# Set image shared
+share_image "${IMAGE_ID}" "${PROJECT_ID}"
+    
+export OS_PROJECT_NAME="dev2"
+export OS_TENANT_NAME="dev2"
+
+# Accept shared image in dev2 project
+accept_shared_image "${IMAGE_ID}"
+
+export OS_PROJECT_NAME="Default Project 37137"
+export OS_TENANT_NAME="Default Project 37137"

--- a/ci/scripts/openstack/utils.sh
+++ b/ci/scripts/openstack/utils.sh
@@ -583,3 +583,51 @@ delete_sg() {
 
   openstack security group delete "${SG}" > /dev/null 2>&1 || true
 }
+
+# Description:
+# Shares image beween projects.
+#
+# Usage share_image <IMAGE_ID> <PROJECT_ID>
+share_image() {
+  local PROJECT_ID IMAGE_ID
+
+  IMAGE_ID="${1:?}"
+  PROJECT_ID="${2:?}"
+
+  openstack image set --shared "${IMAGE_ID}"
+  openstack image add project "${IMAGE_ID}" "${PROJECT_ID}" > /dev/null 2>&1 || true
+}
+
+# Description:
+# Accepts shared image.
+#
+# Usage accept_shared_image <IMAGE_ID>
+accept_shared_image() {
+  local IMAGE_ID
+
+  IMAGE_ID="${1:?}"
+  openstack image set --accept "${IMAGE_ID}"
+}
+
+# Description:
+# Gets Project ID by Project Name.
+#
+# Usage get_project_id <PROJECT_NAME>
+
+get_project_id() {
+  local PROJECT_NAME
+
+  PROJECT_NAME="${1:?}"
+  openstack project list  -f json | jq -r --arg projectName "${PROJECT_NAME}" '.[] | select(.Name == $projectName ).ID'
+}
+
+# Description:
+# Gets IMAGE ID by IMAGE Name.
+#
+# Usage get_image_id <IMAGE_NAME>
+get_image_id() {
+  local IMAGE_NAME
+
+  IMAGE_NAME="${1:?}"
+  openstack image show "$IMAGE_NAME" -f json | jq -r '.id'
+}


### PR DESCRIPTION
As KEEP tests are planned to run in dev2 project, metal3 images must be available in dev2.
This PR adds post condition to pipeline, after each successful built images will be shared to dev2 project.

Related to [this](https://github.com/metal3-io/project-infra/pull/563).