### PR TITLE
Prevent NetworkManager to change /etc/resolv.conf

### DIFF
--- a/ci/scripts/image_scripts/configure_network_centos.sh
+++ b/ci/scripts/image_scripts/configure_network_centos.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# The goal of this script is to prevent NetworkManager set
+# dns server addresses on /etc/resolve.conf 
+
+# make NetworkManager to prevent modifying resolv.conf
+sudo sed -i '/^\[main\]/a dns=none' /etc/NetworkManager/NetworkManager.conf
+sudo systemctl restart NetworkManager.service
+
+# Specify DNS servers for systemd-resolved.
+cat <<EOF | sudo tee /etc/resolv.conf
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+
+EOF

--- a/ci/scripts/image_scripts/configure_network_ubuntu.sh
+++ b/ci/scripts/image_scripts/configure_network_ubuntu.sh
@@ -9,7 +9,7 @@ network:
       dhcp4-overrides:
         use-dns: no
       nameservers:
-        addresses: [1.1.1.1, 1.0.0.1]
+        addresses: [1.1.1.1, 8.8.8.8]
 
 EOF
 # Apply the changes

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -19,6 +19,8 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 export CONTAINER_REGISTRY="registry.nordix.org/quay-io-proxy"
 export DOCKER_HUB_PROXY="registry.nordix.org/docker-hub-proxy"
 
+"${SCRIPTS_DIR}"/configure_network_centos.sh
+
 sudo dnf distro-sync -y
 sudo dnf install -y git make
 

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -8,6 +8,8 @@ export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.15.1"}
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+"${SCRIPTS_DIR}"/configure_network_centos.sh
+
 "${SCRIPTS_DIR}"/install_crio_on_centos.sh
 # NOTE: When running with sudo, PATH is different.
 # /usr/local/bin is NOT read by sudo commands, but rather /usr/bin.


### PR DESCRIPTION
This PR disables NetworKManager resolv.conf file changes. Instead adds dns addresses manually for centos images. 