### PR TITLE
Add libvirt to Jenkins images

### DIFF
--- a/ci/scripts/image_scripts/provision_jumphost_jenkins_base_img.sh
+++ b/ci/scripts/image_scripts/provision_jumphost_jenkins_base_img.sh
@@ -13,8 +13,10 @@ sudo sh -c 'echo "Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries'
 
 # Install required packages.
 sudo apt-get install -y \
-  openjdk-11-jre \
-  python3-pip
+  openjdk-11-jre python3-pip \
+  build-essential qemu-kvm libvirt-daemon-system virt-manager dnsmasq
+
+sudo adduser "${USER}" libvirt
 
 sudo pip3 install \
   python-openstackclient


### PR DESCRIPTION
This adds libvirt and related tools to the Jenkins (and jumphost) images. Libvirt is needed to be able to run BMO e2e tests where we use VMs as BMHs.

I have tested this by building an image manually and then switching the dynamic Jenkins workers to use it. Here is a test run: https://jenkins.nordix.org/job/metal3-bmo-e2e/22/