### PR TITLE
align node image building with packer "retry" workflow

### DIFF
--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -41,7 +41,7 @@ fi
 source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_IMAGE_NAME}-$(get_random_string 10)"
-SOURCE_IMAGE_NAME="CentOS-Stream-9-20220829"
+SOURCE_IMAGE_NAME="CentOS-Stream-9-20230925"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
 SSH_KEYPAIR_NAME="${CI_KEYPAIR_NAME}"

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -14,7 +14,7 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 sudo cp /usr/local/bin/crictl /usr/bin/
 
 echo "${PATH}"|tr ':' '\n'
-sudo mv "${SCRIPTS_DIR}"/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
+sudo cp "${SCRIPTS_DIR}"/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo ls -la /usr/local/bin/retrieve.configuration.files.sh
 sudo dnf update -y
@@ -32,7 +32,7 @@ sudo sed -i 's/enforcing/disabled/g' /etc/selinux/config /etc/selinux/config
 echo  \"Installing kubernetes binaries\"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
 chmod a+x kubeadm kubelet kubectl
-sudo mv kubeadm kubelet kubectl /usr/local/bin/
+sudo cp kubeadm kubelet kubectl /usr/local/bin/
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo /usr/local/bin/retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service /etc/systemd/system/kubelet.service
 sudo /usr/local/bin/retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/10-kubeadm.conf

--- a/ci/scripts/image_scripts/provision_node_image_ubuntu.sh
+++ b/ci/scripts/image_scripts/provision_node_image_ubuntu.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y \
   software-properties-common \
   openssl
 
-sudo mv "${SCRIPTS_DIR}"/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
+sudo cp "${SCRIPTS_DIR}"/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo apt-get install -y conntrack socat
 sudo apt-get install net-tools gcc linux-headers-"$(uname -r)" bridge-utils -y
@@ -57,7 +57,7 @@ sudo apt-get update -y
 echo  "Installing kubernetes binaries"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
 sudo chmod a+x kubeadm kubelet kubectl
-sudo mv kubeadm kubelet kubectl /usr/local/bin/
+sudo cp kubeadm kubelet kubectl /usr/local/bin/
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service /etc/systemd/system/kubelet.service
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
This commit:
  - Changes "mv" commands to "cp" in order to avoid failures in case of packer "retry" actions
  - Also upgrades the Centos 9 Stream source image as the previous version was a year old.