### PR TITLE
Add ci pipeline to build container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,48 +19,6 @@ help:
 	@echo "--------------------------------------------------------------------"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: setup-local-repos
-setup-local-repos: ## Setup nordix repos
-	$(CURDIR)/scripts/init-repo.sh
-
-.PHONY: update-remote-repos
-update-remote-repos: ## Update nordix repos
-	$(CURDIR)/scripts/update-nordix-repos-master.sh
-
-.PHONY: update-nordix-artifacts
-update-nordix-artifacts: ## Update Nordix Artifactory
-	$(CURDIR)/scripts/update-nordix-artifacts.sh
-
-.PHONY: lint-md
-lint-md: ## Lint markdown (ex: make lint-md or make lint-md lint_folder=abspath)
-	docker run --rm \
-		-v "${CURDIR}:/data" \
-		-v "${lint_folder}:/lintdata" \
-		${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver} \
-		mdl -s configs/linter/.mdstylerc.rb "/lintdata"
-
-.PHONY: build-lint-md
-build-lint-md: ## Build Docker Image for markdown lint
-	docker build \
-		-t ${NAME}-md-lint \
-		-f resources/docker/linter/Dockerfile resources/docker/linter/
-
-.PHONY: push-lint-md
-push-lint-md: ## Push Docker Image for Lint markdown to nordix registry
-	docker tag ${NAME}-md-lint:latest ${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver}
-	docker push ${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver}
-
-.PHONY: build-image-builder
-build-image-builder: ## Build Docker Image for qcow2 image building
-	docker build \
-		-t image-builder \
-		-f resources/docker/builder/Dockerfile resources/docker/builder/
-
-.PHONY: push-image-builder
-push-image-builder: ## Push Docker Image for qcow2 image building to nordix registry
-	docker tag image-builder:latest ${image_registry}/metal3/image-builder:${image_builder_img_ver}
-	docker push ${image_registry}/metal3/image-builder:${image_builder_img_ver}
-
 .PHONY: build-go-unittest
 build-go-unittest: ## Build Docker Image for go unit test
 	docker build \
@@ -68,13 +26,15 @@ build-go-unittest: ## Build Docker Image for go unit test
 		-f resources/docker/gotest/Dockerfile resources/docker/gotest/
 	docker tag gotest-unit:latest ${image_registry}/metal3/${NAME}-gotest-unit:${gotest_unit_img_ver}
 
-.PHONY: push-go-unittest
-push-go-unittest: ## Push Docker Image for go unit test to nordix registry
-	docker push ${image_registry}/metal3/${NAME}-gotest-unit:${gotest_unit_img_ver}
+.PHONY: build-container-image
+build-container-image:
+	$(CURDIR)/scripts/build-container-image.sh
 
-.PHONY: lint-shell
-lint-shell: 
-	./scripts/shellcheck.sh
+.PHONY: build-image-builder
+build-image-builder: ## Build Docker Image for qcow2 image building
+	docker build \
+		-t image-builder \
+		-f resources/docker/builder/Dockerfile resources/docker/builder/
 
 .PHONY: build-lint-go
 build-lint-go: ## Build Docker Image for go lint
@@ -82,33 +42,11 @@ build-lint-go: ## Build Docker Image for go lint
 		-t ${NAME}-go-lint \
 		-f resources/docker/linter/golang/Dockerfile resources/docker/linter/golang
 
-.PHONY: push-lint-go
-push-lint-go: ## Push Docker Image for Lint go to nordix registry
-	docker tag ${NAME}-go-lint:latest ${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver}
-	docker push ${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver}
-
-.PHONY: lint-go
-lint-go: ## Lint go and execute gosec (ex: make lint-go or make lint-go lint_folder=abspath)
-	docker run --rm \
-		-v "${CURDIR}:/mnt" \
-		-v "${lint_folder}:/data" \
-		${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver} \
-		sh /mnt/scripts/go-linter.sh
-
-.PHONY: run-dev-env
-run-dev-env: ## Create or start the metal3 dev env vm
-	$(CURDIR)/scripts/run_metal3_vm.sh
-
-.PHONY: test
-test: ## Run unit test for the code in repository
-	docker run --rm \
-                -v "${CURRENT_DIR}/${REPO_NAME}:/go/src/${REPO_PATH}" \
-		-w "/go/src/${REPO_PATH}" -e MAKE_CMD=${MAKE_CMD} -e REPO_NAME=${REPO_NAME} \
-		${image_registry}/metal3/${NAME}-gotest-unit:${gotest_unit_img_ver}
-
-.PHONY: integration_test
-integration_test: ## Run integration test
-	$(CURDIR)/ci/scripts/tests/integration_test.sh
+.PHONY: build-lint-md
+build-lint-md: ## Build Docker Image for markdown lint
+	docker build \
+		-t ${NAME}-md-lint \
+		-f resources/docker/linter/Dockerfile resources/docker/linter/
 
 .PHONY: build_fullstack
 build_fullstack:
@@ -118,6 +56,73 @@ build_fullstack:
 clean_fullstack_builder_vm:
 	$(CURDIR)/ci/scripts/openstack/delete_openstack_vm.sh
 
+.PHONY: integration_test
+integration_test: ## Run integration test
+	$(CURDIR)/ci/scripts/tests/integration_test.sh
+
 .PHONY: integration_test_cleanup
 integration_test_cleanup: ## Clean integration test setup
 	$(CURDIR)/ci/scripts/tests/integration_delete.sh
+
+.PHONY: lint-go
+lint-go: ## Lint go and execute gosec (ex: make lint-go or make lint-go lint_folder=abspath)
+	docker run --rm \
+		-v "${CURDIR}:/mnt" \
+		-v "${lint_folder}:/data" \
+		${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver} \
+		sh /mnt/scripts/go-linter.sh
+
+.PHONY: lint-md
+lint-md: ## Lint markdown (ex: make lint-md or make lint-md lint_folder=abspath)
+	docker run --rm \
+		-v "${CURDIR}:/data" \
+		-v "${lint_folder}:/lintdata" \
+		${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver} \
+		mdl -s configs/linter/.mdstylerc.rb "/lintdata"
+
+.PHONY: lint-shell
+lint-shell: 
+	./scripts/shellcheck.sh
+
+.PHONY: push-lint-go
+push-lint-go: ## Push Docker Image for Lint go to nordix registry
+	docker tag ${NAME}-go-lint:latest ${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver}
+	docker push ${image_registry}/metal3/${NAME}-go-lint:${lint_go_img_ver}
+
+.PHONY: push-go-unittest
+push-go-unittest: ## Push Docker Image for go unit test to nordix registry
+	docker push ${image_registry}/metal3/${NAME}-gotest-unit:${gotest_unit_img_ver}
+
+.PHONY: push-image-builder
+push-image-builder: ## Push Docker Image for qcow2 image building to nordix registry
+	docker tag image-builder:latest ${image_registry}/metal3/image-builder:${image_builder_img_ver}
+	docker push ${image_registry}/metal3/image-builder:${image_builder_img_ver}
+
+.PHONY: push-lint-md
+push-lint-md: ## Push Docker Image for Lint markdown to nordix registry
+	docker tag ${NAME}-md-lint:latest ${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver}
+	docker push ${image_registry}/metal3/${NAME}-md-lint:${lint_md_img_ver}
+
+.PHONY: run-dev-env
+run-dev-env: ## Create or start the metal3 dev env vm
+	$(CURDIR)/scripts/run_metal3_vm.sh
+
+.PHONY: setup-local-repos
+setup-local-repos: ## Setup nordix repos
+	$(CURDIR)/scripts/init-repo.sh
+
+.PHONY: test
+test: ## Run unit test for the code in repository
+	docker run --rm \
+                -v "${CURRENT_DIR}/${REPO_NAME}:/go/src/${REPO_PATH}" \
+		-w "/go/src/${REPO_PATH}" -e MAKE_CMD=${MAKE_CMD} -e REPO_NAME=${REPO_NAME} \
+		${image_registry}/metal3/${NAME}-gotest-unit:${gotest_unit_img_ver}
+
+.PHONY: update-remote-repos
+update-remote-repos: ## Update nordix repos
+	$(CURDIR)/scripts/update-nordix-repos-master.sh
+
+.PHONY: update-nordix-artifacts
+update-nordix-artifacts: ## Update Nordix Artifactory
+	$(CURDIR)/scripts/update-nordix-artifacts.sh
+

--- a/ci/jobs/container_image_building.pipeline
+++ b/ci/jobs/container_image_building.pipeline
@@ -1,0 +1,52 @@
+
+ci_git_url = "https://github.com/Nordix/metal3-dev-tools.git"
+ci_git_credential_id = "nordix-metal3-ci-github-prod-token"
+ci_git_branch = "main"
+image_registry = "quay.io"
+image_registry_organization = "metal3-io"
+image_builder_img_ver = "latest"
+
+pipeline {
+    agent { label 'metal3-workers' }
+    options { ansiColor('xterm') }
+    environment {
+        CONTAINER_IMAGE_HUB = "${image_registry}"
+        CONTAINER_IMAGE_HUB_ORG = "${image_registry_organization}"
+        BUILD_CONTAINER_IMAGE_NAME = "${BUILD_CONTAINER_IMAGE_NAME}"
+        BUILD_CONTAINER_IMAGE_BRANCH = "${ghprbTargetBranch}"
+    }
+    stages {
+        stage('SCM'){
+            options {
+              timeout(time: 5, unit: 'MINUTES')
+            }
+            steps {
+              checkout([$class: 'GitSCM',
+                      branches: [[name: ci_git_branch]],
+                      doGenerateSubmoduleConfigurations: false,
+                      extensions: [[$class: 'WipeWorkspace'],
+                      [$class: 'CleanCheckout'],
+                      [$class: 'CleanBeforeCheckout']],
+                      submoduleCfg: [],
+                      userRemoteConfigs: [[credentialsId: ci_git_credential_id,
+                      url: ci_git_url]]])
+            }
+        }
+        stage('Build and push docker image'){
+            options {
+              timeout(time: 30, unit: 'MINUTES')
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'metal3ci_harbor', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASSWORD')])  {
+                    sh "docker login '${image_registry}' -u $DOCKER_USER -p $DOCKER_PASSWORD"
+                }
+                sh "make build-container-image"
+            }
+        }
+    }
+    post {
+      cleanup {
+          sh "docker logout '${image_registry}'"
+      }
+    }
+}


### PR DESCRIPTION
Additionally, use env vars in build script to make it easier to integrate the script with Jenkins. Also rearranged make targets alphabetically.