### PR TITLE
re enable tdp mmu workaround

### DIFF
--- a/ci/images/centos_userdata.tpl
+++ b/ci/images/centos_userdata.tpl
@@ -9,4 +9,5 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${USERDATA_HOSTNAME}/" /etc/hosts
+  - echo "options kvm tdp_mmu=0" >> /etc/modprobe.d/kvm.conf
   - sed -i 's/#Storage.*/Storage=persistent/' /etc/systemd/journald.conf

--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -9,4 +9,5 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${USERDATA_HOSTNAME}/" /etc/hosts
+  - echo "options kvm tdp_mmu=0" >> /etc/modprobe.d/kvm.conf
   - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link


### PR DESCRIPTION
This workaround was used in the past already but we have disabled it as the issue seemd to be resolved. Recently CI is again experiencing ssh broke pipe issues consistently so as a possible solution this commit re-enables this workaround.