### PR TITLE
Remove unnecessary copy of crictl binary

### DIFF
--- a/ci/scripts/image_scripts/install_crio_on_centos.sh
+++ b/ci/scripts/image_scripts/install_crio_on_centos.sh
@@ -31,4 +31,4 @@ sudo systemctl start crio
 
 # Download crictl
 curl -LO https://github.com/kubernetes-sigs/cri-tools/releases/download/"${CRICTL_VERSION}"/crictl-"${CRICTL_VERSION}"-linux-amd64.tar.gz
-sudo tar -C /usr/local/bin -xzf crictl-"${CRICTL_VERSION}"-linux-amd64.tar.gz
+sudo tar -C /usr/bin -xzf crictl-"${CRICTL_VERSION}"-linux-amd64.tar.gz

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -9,9 +9,6 @@ export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 "${SCRIPTS_DIR}"/install_crio_on_centos.sh
-# NOTE: When running with sudo, PATH is different.
-# /usr/local/bin is NOT read by sudo commands, but rather /usr/bin.
-sudo cp /usr/local/bin/crictl /usr/bin/
 
 echo "${PATH}"|tr ':' '\n'
 sudo cp "${SCRIPTS_DIR}"/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh


### PR DESCRIPTION
crictl is already put in place /usr/local/bin [here](https://github.com/Nordix/metal3-dev-tools/blob/main/ci/scripts/image_scripts/install_crio_on_centos.sh#L34) in the install_crio_on_centos.sh script called a line before. Instead of putting it to /usr/bin in the provision_ script, we now put it in /usr/bin right away. 