### PR TITLE
downgrade packer to 1.9.2

### DIFF
--- a/resources/docker/builder/Dockerfile
+++ b/resources/docker/builder/Dockerfile
@@ -1,5 +1,5 @@
 # Get packer executables
-FROM hashicorp/packer:light AS packer
+FROM hashicorp/packer:light-1.9.2 AS packer
 
 # Build openstack client
 FROM python:3.12-alpine@sha256:ae35274f417fc81ba6ee1fc84206e8517f28117566ee6a04a64f004c1409bdac AS builder


### PR DESCRIPTION
It was observed recently in Metal3 CI, that packer was producing tcp errors at the last stage of the image build process. The images were built and uploaded correctly but packer still finished the build process with a tcp error (sanitized):

```
==> openstack: Error creating image: Post "https://<ostack_api_url>/v3/<proj_id>/volumes/<volume_id>/action":
    read tcp ip:port->ip2:port2: read: connection reset by peer

==> openstack: Provisioning step had errors: Running the cleanup provisioner, if present...

==> openstack: Deleted temporary floating IP '<floating_ip_id>' (<floating_ip>)

==> openstack: Terminating the source server: <vm_id> ...

==> openstack: Error terminating server, may still be around: Resource not found

==> openstack: Waiting for volume packer_<hash> (volume id: <volume_id>) to become available...

==> openstack: Deleting volume: <volume_id> ...

Build 'openstack' errored after 12 minutes 50 seconds: Error creating image:
Post "https://<ostck_url>/v3/<proh_id>/volumes/<volume_id>/action": read tcp ip:port->ip2:port2:
read: connection reset by peer
```

The issue could be caused by a packer bug or incompatibility somewhere between the packer, the packer OpenStack plugin and the OpenStack.

This commit:

- Downgrades the packer version to the previous version in hopes of getting rid of the tcp issue.