### PR TITLE
Install jenkins image related packages to ubuntu base image

### DIFF
--- a/ci/scripts/image_scripts/provision_base_image.sh
+++ b/ci/scripts/image_scripts/provision_base_image.sh
@@ -36,7 +36,14 @@ sudo apt-get install -y \
   make \
   gnupg-agent \
   software-properties-common \
-  openssl
+  openssl \
+  openjdk-11-jre \
+  python3-pip \
+  build-essential \
+  qemu-kvm \
+  libvirt-daemon-system \
+  virt-manager \
+  dnsmasq
 
 # Install docker.
 "${SCRIPTS_DIR}"/setup_docker_ubuntu.sh


### PR DESCRIPTION
This change is related to a CI change where jobs will be run in directly in jenkins worker.