### PR TITLE
WIP: format all YAML consistently as k8s yaml

### DIFF
--- a/ci/scripts/image_scripts/bmh-patch-short-serial.yaml
+++ b/ci/scripts/image_scripts/bmh-patch-short-serial.yaml
@@ -1,4 +1,3 @@
----
 spec:
   rootDeviceHints:
     serialNumber: drive-scsi0-0-0-0


### PR DESCRIPTION
This PR formats all YAML files (*.yaml, *.yml) by the k8s YAML
formatting style. Ie. no indentation for lists, removing leading ---
for multi-document YAML files (it is not necessary) etc.

Similar PR is made in every repository for Metal3.

Signed-off-by: Tuomo Tanskanen <tuomo.tanskanen@est.tech>
