### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - adilGhaffarDev
- - furkatgofurov7
- - kashifest
- - lentzi90
- - mboukhalfa
- - mquhuy
- - Rozzii
- - smoshiur1237
- - Sunnatillo
- - tuminoid
+- metal3-dev-tools-maintainers
+
+reviewers:
+- metal3-dev-tools-maintainers
+- metal3-dev-tools-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  metal3-dev-tools-maintainers:
+  - adilGhaffarDev
+  - furkatgofurov7
+  - kashifest
+  - lentzi90
+  - mboukhalfa
+  - mquhuy
+  - Rozzii
+  - smoshiur1237
+  - Sunnatillo
+  - tuminoid
+
+  metal3-dev-tools-reviewers:


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.