### PR TITLE
Replace the old ssh key with a new one

### DIFF
--- a/ci/scripts/openstack/id_ed25519_metal3ci.pub
+++ b/ci/scripts/openstack/id_ed25519_metal3ci.pub
@@ -1,1 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIpxfHuI2qfTYPrL4+thyHSS78Qj9ehp2/GYxuNXthgS estjorvas@est.tech
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWxiMImeu5YzBDPwAbayWwSa4Fasj6KGpN59t/2yO9V estjorvas@est.tech


### PR DESCRIPTION
This is part of the CI key rotation. We are replacing the old ssh key with the new one.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>