### PR TITLE
Set new jenkins worker label to nordix repo update job

### DIFF
--- a/ci/jobs/update_nordix_repos.pipeline
+++ b/ci/jobs/update_nordix_repos.pipeline
@@ -3,7 +3,7 @@ ci_git_branch = "main"
 ci_git_credential_id = "nordix-metal3-github-ssh"
 
 pipeline {
-  agent { label 'metal3ci-4c16gb-ubuntu' }
+  agent { label 'metal3ci-8c16gb-ubuntu' }
   environment {
     CURRENT_DIR = sh (
                       script: 'pwd',


### PR DESCRIPTION
This PR set new jenkins worker label metal3ci-8c16gb to nordix repo update job as we are not using  metal3ci-4c16gb label anymore