### PR TITLE
:seedling: Change BMO release-0.7 branch to release-0.8 branch

### DIFF
--- a/scripts/update-nordix-repos-master.sh
+++ b/scripts/update-nordix-repos-master.sh
@@ -159,7 +159,7 @@ update_custom_branch "${CAPM3_RELEASE_BRANCHES}" "${LOCAL_CAPM3_REPO}" "${NORDIX
 IPAM_RELEASE_BRANCHES="release-1.5 release-1.6 release-1.7 release-1.8"
 update_custom_branch "${IPAM_RELEASE_BRANCHES}" "${LOCAL_IPAM_REPO}" "${NORDIX_IPAM_REPO}"
 
-BMO_RELEASE_BRANCHES="release-0.4 release-0.5 release-0.6 release-0.7"
+BMO_RELEASE_BRANCHES="release-0.4 release-0.5 release-0.6 release-0.8"
 update_custom_branch "${BMO_RELEASE_BRANCHES}" "${LOCAL_BMO_REPO}" "${NORDIX_BMO_REPO}"
 
 CAPI_RELEASE_BRANCHES="release-1.5 release-1.6 release-1.7 release-1.8"


### PR DESCRIPTION
As we accidentally published BMO v0.8.0-rc.0 instead of v0.7.0-rc.0, we decided to skip release-0.7 and jump directly to release-0.8.