### PR TITLE
Change worker label

### DIFF
--- a/ci/jobs/artifact_cleanup.pipeline
+++ b/ci/jobs/artifact_cleanup.pipeline
@@ -13,7 +13,7 @@ script {
 }
 
 pipeline {
-  agent { label 'metal3-8c16gb-ubuntu' }
+  agent { label 'metal3ci-8c16gb-ubuntu' }
   environment {
     METAL3_CI_USER="metal3ci"
     VM_KEY = "${VM_KEY}"

--- a/ci/jobs/container_image_building.pipeline
+++ b/ci/jobs/container_image_building.pipeline
@@ -5,7 +5,7 @@ image_registry = "quay.io"
 image_registry_organization = "metal3-io"
 
 pipeline {
-    agent { label 'metal3-workers' }
+    agent { label 'metal3ci-8c16gb-ubuntu' }
     options { ansiColor('xterm') }
     environment {
         CONTAINER_IMAGE_HUB = "${image_registry}"


### PR DESCRIPTION
Change worker label to commonly used one metal3ci-8c16gb-ubuntu
also fixes label for container image  building. 