### PR TITLE
Remove @mquhuy from approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
   - adilGhaffarDev
   - kashifest
   - lentzi90
-  - mquhuy
   - Rozzii
   - smoshiur1237
   - Sunnatillo


### PR DESCRIPTION
@mquhuy is not active as an approver in Nordix repos anymore. Thanks Huy for all your contributions.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>